### PR TITLE
Add support for TLS credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Build module - Debug
       shell: pwsh
@@ -41,7 +41,7 @@ jobs:
         PSMODULE_SIGNING_CERT_PASSWORD: ${{ secrets.PSMODULE_SIGNING_CERT_PASSWORD }}
 
     - name: Capture PowerShell Module
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: PSModule
         path: output/*.nupkg
@@ -55,18 +55,29 @@ jobs:
       fail-fast: false
       matrix:
         info:
-        - name: PS x64
+        - name: PS 7.0 x64
+          psversion: '7.0.13'
           os: windows-latest
-          psversion: pwsh
+        - name: PS 7.2 x64
+          psversion: '7.2.7'
+          os: windows-latest
+        - name: PS 7.3 x64
+          psversion: '7.3.0'
+          os: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Restore Built PowerShell Module
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: PSModule
         path: output
+
+    - name: Install PowerShell
+      shell: pwsh
+      run: |
+        tools/AssertPwsh.ps1 -RequiredVersion '${{ matrix.info.psversion }}'
 
     - name: Install Built PowerShell Module
       shell: pwsh
@@ -88,26 +99,27 @@ jobs:
     - name: Run Tests
       shell: pwsh
       run: |
-        & "${{ matrix.info.psversion }}" -NoProfile -File ./build.ps1 -Configuration $env:BUILD_CONFIGURATION -Task Test
+        $pwshPath = "output/pwsh-${{ matrix.info.psversion }}/pwsh$(if ($IsWindows) { '.exe' })"
+        & $pwshPath -NoProfile -File ./build.ps1 -Configuration $env:BUILD_CONFIGURATION -Task Test
         exit $LASTEXITCODE
 
     - name: Upload Test Results
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Unit Test Results (${{ matrix.info.name }})
         path: ./output/TestResults/Pester.xml
 
     - name: Upload Coverage Results
       if: always() && !startsWith(github.ref, 'refs/tags/v')
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Coverage Results (${{ matrix.info.name }})
         path: ./output/TestResults/Coverage.xml
 
     - name: Upload Coverage to codecov
       if: always() && !startsWith(github.ref, 'refs/tags/v')
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         files: ./output/TestResults/Coverage.xml
         flags: ${{ matrix.info.name }}
@@ -121,7 +133,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Restore Built PowerShell Module
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: PSModule
         path: ./

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,14 +24,8 @@
             "type": "PowerShell",
             "request": "launch",
             "script": "${file}",
-            "cwd": "${workspaceFolder}"
-        },
-        {
-            "name": ".NET FullCLR Attach",
-            "type": "clr",
-            "request": "attach",
-            "processId": "${command:pickProcess}",
-            "justMyCode": true,
+            "cwd": "${workspaceFolder}",
+            "createTemporaryIntegratedConsole": true
         },
         {
             "name": ".NET CoreCLR Attach",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -23,7 +23,7 @@
             "type": "shell",
             "args": [
                 "-Command",
-                "Import-Module ${workspaceFolder}/output/PSSPI; Import-Module platyPS; Update-MarkdownHelpModule ${workspaceFolder}/docs/en-US -AlphabeticParamsOrder -RefreshModulePage -UpdateInputOutput"
+                "Import-Module ${workspaceFolder}/output/PSSPI; Import-Module ${workspaceFolder}/tools/Modules/platyPS; Update-MarkdownHelpModule ${workspaceFolder}/docs/en-US -AlphabeticParamsOrder -RefreshModulePage -UpdateInputOutput"
             ],
             "problemMatcher": [],
             "dependsOn": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog for PSSPI
 
+## v0.3.0 - TBD
+
++ Added the following cmdlets for Schannel security contexts
+  + `Get-SchannelCredential` - Get a Schannel SSPI cipher using the legacy Schannel credential struct
+  + `Get-SCHCredential` - Get a Schannel SSPI cipher using the new Schannel credential struct, allows TLS 1.3 (Win 10 1809+)
+  + `Get-SecContextCipherInfo` - Get information about a negotiated TLS context such as the protocol and cipher suite
+  + `New-CryptoSetting` - Build a crypto setting object for use with restricting SCH Credential cipher suite algorithms
+  + `New-TlsParameter` - Build a TLS parameter object for use with restricting SCH Credential TLS options
+
 ## v0.2.0 - 2022-09-09
 
 + Added `AllowPackage` and `RejectPackage` for `New-SSPICredential` to specify what package a `Negotiate` credential can utilise

--- a/docs/en-US/Get-SCHCredential.md
+++ b/docs/en-US/Get-SCHCredential.md
@@ -1,0 +1,179 @@
+---
+external help file: PSSPI.dll-Help.xml
+Module Name: PSSPI
+online version: https://www.github.com/jborean93/PSSPI/blob/main/docs/en-US/Get-SCHCredential.md
+schema: 2.0.0
+---
+
+# Get-SCHCredential
+
+## SYNOPSIS
+Creates an Schannel SSPI credential based on the newer SCH_CREDENTIALS structure.
+
+## SYNTAX
+
+```
+Get-SCHCredential [-CredentialUse <CredentialUse>] [-Certificate <X509Certificate[]>] [-RootStore <X509Store>]
+ [-SessionLifespanMS <Int32>] [-Flags <SchannelCredFlags>] [-TlsParameter <TlsParameter[]>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+Gets a Schannel SSPI credential for use with the `Microsoft Unified Security Protocol Provider` provider.
+The credential is retrieved using the `SCH_CREDENTIALS` structure added in Windows 10 Build 1809 and supports all the modern protocols and ciphers like TLS 1.3.
+The [Get-SchannelCredential](./Get-SchannelCredential.md) is the older Schannel credential structure that can be used for Windows versions older than Windows 10 Build 1809.
+
+By default it allows all the system configured protocols and ciphers and utilises TLS Parameters to disable certain protocols and cipher suites.
+Use [New-TlsParameter](./New-TlsParameter.md) to learn more about how to disable certain protocols and ciphers.
+
+## EXAMPLES
+
+### Example 1 - Get client Schannel credential with system defaults
+```powershell
+PS C:\> Get-SCHCredential
+```
+
+Gets a Schannel credential for a client to use with `New-SecContext`.
+This Schannel credential is set to use the system defaults.
+
+### Example 2 - Get client Schannel and disable weak protocols and ciphers
+```powershell
+PS C:\> Get-SCHCredential -Flags SCH_USE_STRONG_CRYPTO
+```
+
+Gets a Schannel credential with the `SCH_USE_STRONG_CRYPTO` flag specified which disables any weak protocols and cipher suites from being used.
+
+### Example 3 - Get server Schannel with certificate
+```powershell
+PS C:\> $thumbprint = '...' # This is dependent on your environment
+PS C:\> $cert = Get-Item Cert:\LocalMachine\My\$thumbprint
+PS C:\> Get-SCHCredential -CredentialUse SECPKG_CRED_INBOUND -Certificate $cert
+```
+
+Gets a Schannel credential for use as a server that is backed by the certificate requested.
+
+## PARAMETERS
+
+### -Certificate
+The certificate(s) to use when authenticating the caller.
+When passing an empty list, the client will depend on Schannel to find an approriate certificatefor the authentication process.
+For an inbound credential these are the certificates Schannel will use to present to the client.
+The certificate selected is based on the capabilities offered by the client and what fits best.
+At least one certificate must be specified when `-CredentialUse` has the `SECPKG_CRED_INBOUND` flag.
+
+```yaml
+Type: X509Certificate[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CredentialUse
+How the credential is to be used.
+Defaults to `SECPKG_CRED_OUTBOUND` which is used by a client.
+Set to `SECPKG_CRED_INBOUND` to create a credential for use by a server/acceptor.
+
+```yaml
+Type: CredentialUse
+Parameter Sets: (All)
+Aliases:
+Accepted values: SECPKG_CRED_INBOUND, SECPKG_CRED_OUTBOUND, SECPKG_CRED_BOTH, SECPKG_CRED_DEFAULT, SECPKG_CRED_AUTOLOGON_RESTRICTED, SECPKG_CRED_PROCESS_POLICY_ONLY
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Flags
+Flags to set which control the behaviour of the Schannel operation.
+These flags can control behaviour like how certificates are validated, client auth certificate lookups, and more.
+
+```yaml
+Type: SchannelCredFlags
+Parameter Sets: (All)
+Aliases:
+Accepted values: None, SCH_CRED_NO_SYSTEM_MAPPER, SCH_CRED_NO_SERVERNAME_CHECK, SCH_CRED_MANUAL_CRED_VALIDATION, SCH_CRED_NO_DEFAULT_CREDS, SCH_CRED_AUTO_CRED_VALIDATION, SCH_CRED_USE_DEFAULT_CREDS, SCH_CRED_DISABLE_RECONNECTS, SCH_CRED_REVOCATION_CHECK_END_CERT, SCH_CRED_REVOCATION_CHECK_CHAIN, SCH_CRED_REVOCATION_CHECK_CHAIN_EXCLUDE_ROOT, SCH_CRED_IGNORE_NO_REVOCATION_CHECK, SCH_CRED_IGNORE_REVOCATION_OFFLINE, SCH_CRED_RESTRICTED_ROOTS, SCH_CRED_REVOCATION_CHECK_CACHE_ONLY, SCH_CRED_CACHE_ONLY_URL_RETRIEVAL, SCH_CRED_SNI_CREDENTIAL, SCH_CRED_MEMORY_STORE_CERT, SCH_CRED_CACHE_ONLY_URL_RETRIEVAL_ON_CREATE, SCH_SEND_ROOT_CERT, SCH_CRED_SNI_ENABLE_OCSP, SCH_SEND_AUX_RECORD, SCH_USE_STRONG_CRYPTO, SCH_USE_PRESHAREDKEY_ONLY, SCH_USE_DTLS_ONLY, SCH_ALLOW_NULL_ENCRYPTION, SCH_CRED_DEFERRED_CRED_VALIDATION
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RootStore
+Used for inbound/acceptor credentials and is the X509 store that contains the self-signed root certificate for certification authorities trusted by the application.
+This is used only be server-side applications that require client authentication.
+
+```yaml
+Type: X509Store
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SessionLifespanMS
+The number of milliseconds that Schannel keeps the session in its session cache.
+After this time has passed, any new connections between the client and server require a new Schannel session.
+The default is `0` which is set to use the system wide configured default of 10 hours.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TlsParameter
+A list of TLS parameters that indicate TLS parameter restrictions.
+Use [New-TlsParameter](./New-TlsParameter.md) to build the parameters that can restrict the protocols and cipher suites this credential can use.
+
+```yaml
+Type: TlsParameter[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+## OUTPUTS
+
+### PSSPI.Credential
+The generated credential handle. This object has the following properties:
+
++ `SafeHandle`: The handle to the SSPI credentials generated.
+
++ `Expiry`: The expiry of the credentials.
+
+## NOTES
+
+## RELATED LINKS
+
+[SCH_CREDENTIALS](https://learn.microsoft.com/en-us/windows/win32/api/schannel/ns-schannel-sch_credentials)

--- a/docs/en-US/Get-SchannelCredential.md
+++ b/docs/en-US/Get-SchannelCredential.md
@@ -1,0 +1,233 @@
+---
+external help file: PSSPI.dll-Help.xml
+Module Name: PSSPI
+online version: https://www.github.com/jborean93/PSSPI/blob/main/docs/en-US/Get-SchannelCredential.md
+schema: 2.0.0
+---
+
+# Get-SchannelCredential
+
+## SYNOPSIS
+Creates a Schannel SSPI credential based on the legacy SCHANNEL_CRED structure.
+
+## SYNTAX
+
+```
+Get-SchannelCredential [-CredentialUse <CredentialUse>] [-Certificate <X509Certificate[]>]
+ [-RootStore <X509Store>] [-SessionLifespanMS <Int32>] [-Flags <SchannelCredFlags>]
+ [-SupportedAlgs <AlgorithmId[]>] [-Protocols <SchannelProtocols>] [-MinimumCipherStrength <Int32>]
+ [-MaximumCipherStrength <Int32>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Gets a Schannel SSPI credential for use with the `Microsoft Unified Security Protocol Provider` provider.
+The credential is retrieved using the `SCHANNEL_CRED` structure that is the older legacy Schannel credential structure.
+It has been deprected in favour of `SCH_CREDENTIALS` exposed by [Get-SCHCredential](./Get-SCHCredential.md) which should be used if on a new enough Windows version.
+
+By default it allows all the system configured protocols and ciphers except for TLS 1.3.
+It also can be used to explicitly set the list of protocols and ciphers it will use with the `-Protocols` and `-SupportedAlgs` parameters.
+
+## EXAMPLES
+
+### Example 1 - Get client Schannel credential with system defaults
+```powershell
+PS C:\> Get-SchannelCredential
+```
+
+Gets a Schannel credential for a client to use with `New-SecContext`.
+This Schannel credential is set to use the system defaults.
+
+### Example 2 - Get client Schannel and disable weak protocols and ciphers
+```powershell
+PS C:\> Get-SchannelCredential -Flags SCH_USE_STRONG_CRYPTO
+```
+
+Gets a Schannel credential with the `SCH_USE_STRONG_CRYPTO` flag specified which disables any weak protocols and cipher suites from being used.
+
+### Example 3 - Get server Schannel with certificate
+```powershell
+PS C:\> $thumbprint = '...' # This is dependent on your environment
+PS C:\> $cert = Get-Item Cert:\LocalMachine\My\$thumbprint
+PS C:\> Get-SchannelCredential -CredentialUse SECPKG_CRED_INBOUND -Certificate $cert
+```
+
+Gets a Schannel credential for use as a server that is backed by the certificate requested.
+
+## PARAMETERS
+
+### -Certificate
+The certificate(s) to use when authenticating the caller.
+When passing an empty list, the client will depend on Schannel to find an approriate certificatefor the authentication process.
+For an inbound credential these are the certificates Schannel will use to present to the client.
+The certificate selected is based on the capabilities offered by the client and what fits best.
+At least one certificate must be specified when `-CredentialUse` has the `SECPKG_CRED_INBOUND` flag.
+
+```yaml
+Type: X509Certificate[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CredentialUse
+How the credential is to be used.
+Defaults to `SECPKG_CRED_OUTBOUND` which is used by a client.
+Set to `SECPKG_CRED_INBOUND` to create a credential for use by a server/acceptor.
+
+```yaml
+Type: CredentialUse
+Parameter Sets: (All)
+Aliases:
+Accepted values: SECPKG_CRED_INBOUND, SECPKG_CRED_OUTBOUND, SECPKG_CRED_BOTH, SECPKG_CRED_DEFAULT, SECPKG_CRED_AUTOLOGON_RESTRICTED, SECPKG_CRED_PROCESS_POLICY_ONLY
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Flags
+Flags to set which control the behaviour of the Schannel operation.
+These flags can control behaviour like how certificates are validated, client auth certificate lookups, and more.
+
+```yaml
+Type: SchannelCredFlags
+Parameter Sets: (All)
+Aliases:
+Accepted values: None, SCH_CRED_NO_SYSTEM_MAPPER, SCH_CRED_NO_SERVERNAME_CHECK, SCH_CRED_MANUAL_CRED_VALIDATION, SCH_CRED_NO_DEFAULT_CREDS, SCH_CRED_AUTO_CRED_VALIDATION, SCH_CRED_USE_DEFAULT_CREDS, SCH_CRED_DISABLE_RECONNECTS, SCH_CRED_REVOCATION_CHECK_END_CERT, SCH_CRED_REVOCATION_CHECK_CHAIN, SCH_CRED_REVOCATION_CHECK_CHAIN_EXCLUDE_ROOT, SCH_CRED_IGNORE_NO_REVOCATION_CHECK, SCH_CRED_IGNORE_REVOCATION_OFFLINE, SCH_CRED_RESTRICTED_ROOTS, SCH_CRED_REVOCATION_CHECK_CACHE_ONLY, SCH_CRED_CACHE_ONLY_URL_RETRIEVAL, SCH_CRED_SNI_CREDENTIAL, SCH_CRED_MEMORY_STORE_CERT, SCH_CRED_CACHE_ONLY_URL_RETRIEVAL_ON_CREATE, SCH_SEND_ROOT_CERT, SCH_CRED_SNI_ENABLE_OCSP, SCH_SEND_AUX_RECORD, SCH_USE_STRONG_CRYPTO, SCH_USE_PRESHAREDKEY_ONLY, SCH_USE_DTLS_ONLY, SCH_ALLOW_NULL_ENCRYPTION, SCH_CRED_DEFERRED_CRED_VALIDATION
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MaximumCipherStrength
+{{ Fill MaximumCipherStrength Description }}
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MinimumCipherStrength
+{{ Fill MinimumCipherStrength Description }}
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Protocols
+Explicitly set the TLS protocols that the credential can use.
+If omitted then all the protocols enabled system wide will be used.
+The system wide settings take precedence over this value, e.g. TLS1.0 cannot be used if disabled in the registry.
+
+```yaml
+Type: SchannelProtocols
+Parameter Sets: (All)
+Aliases:
+Accepted values: SP_PROT_NONE, SP_PROT_PCT1_SERVER, SP_PROT_PCT1_CLIENT, SP_PROT_PCT1, SP_PROT_SSL2_SERVER, SP_PROT_SSL2_CLIENT, SP_PROT_SSL2, SP_PROT_SSL3_SERVER, SP_PROT_SSL3_CLIENT, SP_PROT_SSL3, SP_PROT_TLS1_SERVER, SP_PROT_TLS1_0_SERVER, SP_PROT_SSL3TLS1_SERVERS, SP_PROT_TLS1_CLIENT, SP_PROT_SSL3TLS1_CLIENTS, SP_PROT_TLS1_0_CLIENT, SP_PROT_TLS1, SP_PROT_TLS1_0, SP_PROT_SSL3TLS1, SP_PROT_TLS1_1_SERVER, SP_PROT_TLS1_1_CLIENT, SP_PROT_TLS1_1, SP_PROT_TLS1_2_SERVER, SP_PROT_TLS1_2_CLIENT, SP_PROT_TLS1_2, SP_PROT_TLS1_3_SERVER, SP_PROT_TLS1_3_CLIENT, SP_PROT_TLS1_3, SP_PROT_DTLS_SERVER, SP_PROT_DTLS1_0_SERVER, SP_PROT_DTLS1_0_CLIENT, SP_PROT_DTLS_CLIENT, SP_PROT_DTLS1_0, SP_PROT_DTLS, SP_PROT_DTLS1_2_SERVER, SP_PROT_DTLS1_2_CLIENT, SP_PROT_DTLS1_2, SP_PROT_UNI_SERVER, SP_PROT_SERVERS, SP_PROT_UNI_CLIENT, SP_PROT_CLIENTS, SP_PROT_UNI, SP_PROT_ALL
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RootStore
+Used for inbound/acceptor credentials and is the X509 store that contains the self-signed root certificate for certification authorities trusted by the application.
+This is used only be server-side applications that require client authentication.
+
+```yaml
+Type: X509Store
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SessionLifespanMS
+The number of milliseconds that Schannel keeps the session in its session cache.
+After this time has passed, any new connections between the client and server require a new Schannel session.
+The default is `0` which is set to use the system wide configured default of 10 hours.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SupportedAlgs
+A list of algorithms that are available to the credential.
+It is used to have the credential only use the algorithms specified.
+This essentially controls the cipher suites that are available to the credential for use.
+Omitting this value will have the credential use the system defaults.
+
+```yaml
+Type: AlgorithmId[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+## OUTPUTS
+
+### PSSPI.Credential
+The generated credential handle. This object has the following properties:
+
++ `SafeHandle`: The handle to the SSPI credentials generated.
+
++ `Expiry`: The expiry of the credentials.
+
+## NOTES
+This credential even when used on newer systems that support TLS 1.3 will never use it.
+Te [Get-SCHCredential](./Get-SCHCredential.md) cmdlet must be used to support TLS 1.3.
+
+## RELATED LINKS
+
+[SCHANNEL_CRED](https://learn.microsoft.com/en-us/windows/win32/api/schannel/ns-schannel-schannel_cred)
+[ALG_ID](https://learn.microsoft.com/en-us/windows/win32/seccrypto/alg-id)

--- a/docs/en-US/Get-SecContextCipherInfo.md
+++ b/docs/en-US/Get-SecContextCipherInfo.md
@@ -1,0 +1,77 @@
+---
+external help file: PSSPI.dll-Help.xml
+Module Name: PSSPI
+online version: https://www.github.com/jborean93/PSSPI/blob/main/docs/en-US/Get-SCHCredential.md
+schema: 2.0.0
+---
+
+# Get-SecContextCipherInfo
+
+## SYNOPSIS
+Get TLS cipher information from a negotiated context.
+
+## SYNTAX
+
+```
+Get-SecContextCipherInfo -Context <SecurityContext[]> [<CommonParameters>]
+```
+
+## DESCRIPTION
+Gets the TLS protocol, cipher suite, and cipher algorithm information that was negotiated in a Schannel TLS context.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> $cred = Get-SCHCredential
+PS C:\> $ctx = New-SecContext -Credential $cred
+PS C:\> ... # Set up the context
+PS C:\> Get-SecContextCipherInfo -Context $ctx
+```
+
+Gets the cipher information of a negotiated TLS context.
+
+## PARAMETERS
+
+### -Context
+The Schannel security context to query.
+This context must have completed the authentication stage until it has been marked as Ok from `Step-InitSecContext`.
+
+```yaml
+Type: SecurityContext[]
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### PSSPI.SecurityContext[]
+An array of security contexts can be piped into this cmdlet.
+
+## OUTPUTS
+
+### PSSPI.Commands.CipherInfo
+The CipherInfo object contains the following properties
+
++ `Protocol` - The TLS protocol that was negotiated, e.g. `TLS1_3`
+
++ `CipherSuite` - The Cipher Suite negotiated as a string, e.g. `TLS_AES_256_GCM_SHA384`
+
++ `Cipher` - The cipher/auth algorithm that was used, e.g. `AES`
+
++ `CipherLength` - The length in bits of the cipher/auth algorithm that was used, e.g. `256
+
+## NOTES
+
+## RELATED LINKS
+
+[SecPkgContext_CipherInfo](https://learn.microsoft.com/en-us/windows/win32/api/schannel/ns-schannel-secpkgcontext_cipherinfo)

--- a/docs/en-US/New-CryptoSetting.md
+++ b/docs/en-US/New-CryptoSetting.md
@@ -1,0 +1,189 @@
+---
+external help file: PSSPI.dll-Help.xml
+Module Name: PSSPI
+online version: https://www.github.com/jborean93/PSSPI/blob/main/docs/en-US/New-CryptoSetting.md
+schema: 2.0.0
+---
+
+# New-CryptoSetting
+
+## SYNOPSIS
+Creates a Crypto Setting object for use as a TLS Parameter to disable certain cipher suites.
+
+## SYNTAX
+
+```
+New-CryptoSetting -Usage <SchannelCryptoUsage> -Algorithm <String> [-ChainingMode <String[]>]
+ [-MinBitLength <Int32>] [-MaxBitLength <Int32>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Builds a Crypto Setting object that represents a cipher suite cryptography algorithm.
+It doesn't represent a single cipher suite but rather components of a cipher suite allowing you to disable weaker components by type rather than by name.
+It is used in TLS Parameters to restrict the cipher suites used in a TLS handshake.
+It is based off the `CRYPTO_SETTINGS` struct in `Schannel.h` and is used with the newer SCH style credentials added in Windows 10 Build 1809.
+Use these crypto settings as a value for `New-TlsParameter -CryptoSetting ...` which is used with `Get-SCHCredential`.
+Multiple crypto setting objects can be used with `-CryptoSetting` allowing the caller to block multiple algorithms.
+
+## EXAMPLES
+
+### Example 1 - Disable TLS_CHACHA20_POLY1305_SHA256
+```powershell
+PS C:\> New-CryptoSetting -Usage Cipher -Algorithm CHACHA20_POLY1305
+```
+
+Creates a crypto setting that applies to any cipher suites that use the CHACHA20_POLY1305 algorithm.
+When used with `New-TlsParameter -DisableCrypto $cs` it will disable the usage of the TLS 1.3 cipher suite `TLS_CHACHA20_POLY1305_SHA256`
+
+### Example 2 - Disable AES 256
+```powershell
+PS C:\> New-CryptoSetting -Usage Cipher -Algorithm AES -MaxBitLength 128
+```
+
+Creates a crypto setting that applies to any cipher suites that use the AES algorithm and has a bit length greater than 128.
+
+### Example 3 - Disable AES 128
+```powershell
+PS C:\> New-CryptoSetting -Usage Cipher -Algorithm AES -MinBitLength 256
+```
+
+Creates a crypto setting that applies to any cipher suites that use the AES algorithm and has a bit length less than 256.
+
+### Example 4 - Disable SHA256 hashing algorithm
+```powershell
+PS C:\> New-CryptoSetting -Usage Digest -Algorithm SHA256
+```
+
+Creates a crypto setting that applies to any cipher suites that use the SHA256 digest/signature hashing algorithm.
+For TLS 1.3 this will disable `TLS_AES_128_GCM_SHA256 ` but not `TLS_AES_256_GCM_SHA384`
+
+## PARAMETERS
+
+### -Algorithm
+The identifier of the algorithm to restrict.
+The identifier is dependent on the `-Usage` option chosen and is used to identify a component of the TLS cipher suite to disable.
+For example `-Usage Cipher -Algorithm RC4` will disable and TLS cipher suite that uses `RC4` as the session/encryption cipher.
+This parameter supports tab completion for known algorithms.
+
+While the TLS Cipher Suite string uses `ECDHE` and `DHE`, they are represented by `ECDH` and `DH` as an algorithm in SSPI.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ChainingMode
+If the cipher algorithm specified is a block mode cipher this can be used to disable the algorithm when using a particular chaining/block mode.
+For example `-Usage Cipher -Algorithm AES -Chaining Mode ChainingModeCBC` will disable cipher suites that use the AES cipher in CBC mode.
+A maximum of 16 chaining modes can be specified for this parameter.
+A list of known chaining modes can be found under `BCRYPT_CHAINING_MODE` at https://learn.microsoft.com/en-us/windows/win32/seccng/cng-property-identifiers.
+This parameter supports tab completion for known algorithms.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MaxBitLength
+Specifies the maximum bit length of a cipher that is excluded from the ciphers specified by the crypto settings object.
+For example specifying `-MaxBitLength 128` will disable any ciphers that are greater than 128 bits, i.e. AES256.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MinBitLength
+Specifies the minimum bit length of a cipher that is excluded from the ciphers specified by the crypto settings object.
+For example specifying `-MinBitLength 256` will disable any ciphers that are less than 256 bites, i.e. AES128.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Usage
+The algorithm type/usage that this crypto setting represents.
+This can be set to the following values
+
++ `KeyExchange` - Algorithm in the key exchange to disable
+
++ `Signature` - Algorithm in the signature to disable
+
++ `Cipher` - Algorithm in the cipher/authentication method to disable
+
++ `Digest` - Algorithm in the cipher/authentication digest to disable
+
++ `CertSig` - Algorithm and/or hash used to sign the certificate to disable, this is the `signature_algorithms` extension type in the TLS client hello
+
+The usage value and algorithm are used by the crypto settings object to define the cipher suites which are blocked from being used.
+
+```yaml
+Type: SchannelCryptoUsage
+Parameter Sets: (All)
+Aliases:
+Accepted values: KeyExchange, Signature, Cipher, Digest, CertSig
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+## OUTPUTS
+
+### PSSPI.CryptoSetting
+An object representing the crypto setting requested. It contains the following properties
+
++ `Usage`
+
++ `Algorithm`
+
++ `ChainingModes`
+
++ `MinBitLength`
+
++ `MaxBitLength`
+
+## NOTES
+
+## RELATED LINKS
+
+[CRYPTO_SETTINGS](https://learn.microsoft.com/en-us/windows/win32/api/schannel/ns-schannel-crypto_settings)
+[eTlsAlgorithmUsage](https://learn.microsoft.com/en-us/windows/win32/api/schannel/ne-schannel-etlsalgorithmusage)
+[Cipher Suites in TLS Schannel](https://learn.microsoft.com/en-us/windows/win32/secauthn/cipher-suites-in-schannel)

--- a/docs/en-US/New-TlsParameter.md
+++ b/docs/en-US/New-TlsParameter.md
@@ -1,0 +1,138 @@
+---
+external help file: PSSPI.dll-Help.xml
+Module Name: PSSPI
+online version: https://www.github.com/jborean93/PSSPI/blob/main/docs/en-US/New-TlsParameter.md
+schema: 2.0.0
+---
+
+# New-TlsParameter
+
+## SYNOPSIS
+Creates a TLS parameter object for use with an SCH credential (Schannel).
+
+## SYNTAX
+
+```
+New-TlsParameter [-AlpnId <String[]>] [-DisabledProtocol <SchannelProtocols>]
+ [-DisabledCrypto <CryptoSetting[]>] [-Optional] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Builds a TLS Parameter object that represents TLS parameter restrictions.
+It can be used to disable TLS protocols or with `New-CryptoSetting` to disable certain cipher suites.
+It is based off the `TLS_PARMETERS` struct in `Schannel.h` and is used with the newer SCH style credential added in Windows 10 Build 1809.
+Multiple TLS parmeter objects can be used with `Get-SCHCredential -TlsParameter`.
+
+## EXAMPLES
+
+### Example 1 - Create Parameter to only allow TLS 1.2 connections
+```powershell
+PS C:\> New-TlsParameter -DisableProtocol (-bnot [PSSPI.SchannelProtocols]::SP_PROT_TLS1_3)
+```
+
+Creates a TLS Parameter that disables all protocols except for TLS 1.3
+
+### Example 2 - Create Parameter to disable TLS 1.0 and TLS 1.1
+```powershell
+PS C:\> New-TlsParameter -DisableProtocol SP_PROT_TLS1_0, SP_PROT_TLS1_1
+```
+
+Creates a TLS Parameter that disabled TLS 1.0 and TLS 1.1.
+
+## PARAMETERS
+
+### -AlpnId
+The ALPN IDs the parameter applies to.
+When omitted, the parameter applies to any negotiated protocols.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DisabledCrypto
+The crypto settings as created by [New-CryptoSetting](./New-CryptoSetting.md) to disable.
+A maximum of 16 settings can be applied to a single TLS Parameter.
+This is used to disable cipher suite algorithms that are used in the connection rather than the full TLS protocol.
+
+```yaml
+Type: CryptoSetting[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DisabledProtocol
+The TLS protocols to disable.
+Any protocols specified here will not be available for the Schannel credential to use.
+For example `-DisabledProtocol SP_PROT_TLS1_3` will disable TLS 1.3 on the handshake.
+The `-bnot` operator can be used to inverse the selection so that all the protocols but the one specified are disabled, effectively making it an allow list of protocols.
+For example `-DisableProtocol (-bnot ([PSSPI.Schannel]::SP_PROT_TLS1_3))` will disable all protocols but TLS 1.2.
+
+Multiple protocols can be specified for this parameter.
+
+```yaml
+Type: SchannelProtocols
+Parameter Sets: (All)
+Aliases:
+Accepted values: SP_PROT_NONE, SP_PROT_PCT1_SERVER, SP_PROT_PCT1_CLIENT, SP_PROT_PCT1, SP_PROT_SSL2_SERVER, SP_PROT_SSL2_CLIENT, SP_PROT_SSL2, SP_PROT_SSL3_SERVER, SP_PROT_SSL3_CLIENT, SP_PROT_SSL3, SP_PROT_TLS1_SERVER, SP_PROT_TLS1_0_SERVER, SP_PROT_SSL3TLS1_SERVERS, SP_PROT_TLS1_CLIENT, SP_PROT_SSL3TLS1_CLIENTS, SP_PROT_TLS1_0_CLIENT, SP_PROT_TLS1, SP_PROT_TLS1_0, SP_PROT_SSL3TLS1, SP_PROT_TLS1_1_SERVER, SP_PROT_TLS1_1_CLIENT, SP_PROT_TLS1_1, SP_PROT_TLS1_2_SERVER, SP_PROT_TLS1_2_CLIENT, SP_PROT_TLS1_2, SP_PROT_TLS1_3_SERVER, SP_PROT_TLS1_3_CLIENT, SP_PROT_TLS1_3, SP_PROT_DTLS_SERVER, SP_PROT_DTLS1_0_SERVER, SP_PROT_DTLS1_0_CLIENT, SP_PROT_DTLS_CLIENT, SP_PROT_DTLS1_0, SP_PROT_DTLS, SP_PROT_DTLS1_2_SERVER, SP_PROT_DTLS1_2_CLIENT, SP_PROT_DTLS1_2, SP_PROT_UNI_SERVER, SP_PROT_SERVERS, SP_PROT_UNI_CLIENT, SP_PROT_CLIENTS, SP_PROT_UNI, SP_PROT_ALL
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Optional
+Marks the parameter as optional.
+This is only used for the server/acceptor as a way to mark a parameter that can be ignored if it causes the handshake from the client to be rejected.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+## OUTPUTS
+
+### PSSPI.TlsParameter
+An object representing the TLS parameter requested. It contains the following properties
+
++ `AlpnIds`
+
++ `DisabledProtocols`
+
++ `DisabledCryptos`
+
++ `Optional`
+
+## NOTES
+
+## RELATED LINKS
+
+[TLS_PARAMETERS](https://learn.microsoft.com/en-us/windows/win32/api/schannel/ns-schannel-tls_parameters)

--- a/docs/en-US/PSSPI.md
+++ b/docs/en-US/PSSPI.md
@@ -8,9 +8,18 @@ Locale: en-US
 
 # PSSPI Module
 ## Description
-PowerShell module for interacting with Security Support Provider Interface (SSPI).
+PowerShell module for interacting with Security Support Provider Interface (SSPI). More information about the Schannel credentials can be found at about_TLSAuthentication .
 
 ## PSSPI Cmdlets
+### [Get-SchannelCredential](Get-SchannelCredential.md)
+Creates a Schannel SSPI credential based on the legacy SCHANNEL_CRED structure.
+
+### [Get-SCHCredential](Get-SCHCredential.md)
+Creates an Schannel SSPI credential based on the newer SCH_CREDENTIALS structure.
+
+### [Get-SecContextCipherInfo](Get-SecContextCipherInfo.md)
+Get TLS cipher information from a negotiated context.
+
 ### [Get-SSPICredential](Get-SSPICredential.md)
 Get a SSPI credential handle.
 
@@ -20,11 +29,17 @@ Gets security package information.
 ### [New-ChannelBindingBuffer](New-ChannelBindingBuffer.md)
 Create channel binding structure for authentication.
 
+### [New-CryptoSetting](New-CryptoSetting.md)
+Creates a Crypto Setting object for use as a TLS Parameter to disable certain cipher suites.
+
 ### [New-SecBuffer](New-SecBuffer.md)
 Create an SSPI security buffer
 
 ### [New-SecContext](New-SecContext.md)
 Creates an SSPI context.
+
+### [New-TlsParameter](New-TlsParameter.md)
+Creates a TLS parameter object for use with an SCH credential (Schannel).
 
 ### [Set-KdcProxy](Set-KdcProxy.md)
 Set the KDC proxy settings on an SSPI credential.

--- a/docs/en-US/about_TLSAuthentication.md
+++ b/docs/en-US/about_TLSAuthentication.md
@@ -1,0 +1,119 @@
+# TLS Authentication
+## about_TLSAuthentication
+
+# SHORT DESCRIPTION
+On Windows, SSPI is used to setup a TLS connection and provides the API that programs use to perform the handshake.
+This is a similar role to OpenSSL, except the APIs follow a different format.
+This doc aims to provide some examples of how to use PSSPI to test out TLS connections.
+
+# CREDENTIAL TYPES
+There are 2 Schannel credential types that can be used with SSPI:
+
++ `SCHANNEL_CRED` - Retrieved with `Get-SchannelCredential`
+
++ `SCH_CREDENTIALS` - Retrieved with `Get-SCHCredential`
+
+The `SCHANNEL_CRED` is the legacy credential type and is deprecated in favour of `SCH_CREDENTIALS`.
+It can only use TLS 1.2 or lower and provides a limited way of controlling the cipher suites that are used in the connection.
+It operates on an allow list where the system defaults are used but when a protocols is specified it will only allow the ones specified to be used.
+
+The `SCH_CREDENTIALS` is the new credential type added with Windows 10 Build 1809.
+It must be used if the client or server wishes to negotiate with TLS 1.3.
+The ability to restrict protocols and cipher suites is a lot more robust than `SCHANNEL_CRED` and operates on a deny mechanism.
+This deny list is specified through TLS Parameters created by `New-TlsParameter` which each parameter can specify TLS protocols to restrict as well as crypto algorithms through the `-DisabledCrypto` parameter.
+
+Both credential types support the `-Flags` field which can be set to various flags that control the handshake behaviour.
+The `SCH_USE_STRONG_CRYPTO` can, and should, be specified so that Schannel restricts the default protocol and cipher suite list to stronger algorithms than what the default offers.
+
+The `Get-SCHCredential` cmdlet should be used for Schannel authentication attempts on any host that runs with Windows 10 Build 1809 or newer.
+The `Get-SchannelCredential` is only available for older hosts and support for it is limited.
+
+# AUTHENTICATION EXAMPLE
+
+The authentication phase is known as the TLS handshake and requires multiple calls to the SSPI API to complete.
+The exchange is quite complex but hopefully this example helps to illustrate what is needed.
+
+```powershell
+# The client will get its credentials and build the security context.
+# It is with Get-SCHCredential that restrictions can be placed on what TLS
+# protocols are used and other authentication options.
+$cCred = Get-SCHCredential
+$cCtx = New-SecContext -Credential $cCred
+
+# The server must provide a X509Certificate object when getting its
+# credentials. The example here uses a hardcoded thumbprint but the
+# cert provider can be used to scan the cert store and filter out the certs
+# needed dynamically.
+$thumbprint = '2B192AD47337A1DEEAFB087E51F6BB294F713671'
+$cert = Get-Item Cert:\LocalMachine\My\$thumbprint
+$sCred = Get-SCHCredential -CredentialUse SECPKG_CRED_INBOUND -Certificate $cert
+$sCtx = New-SecContext -Credential $sCred
+
+# There are multiple steps needed to complete the authentication phase. This
+# example has been tested with TLS 1.3 where the client and server both produce
+# two tokens that each other must process.
+$sRes = $null
+while ($true) {
+    $stepParams = @{
+        Context = $cCtx
+        Target = "target-host"  # Used for SNI and cert CN verification
+        ContextReq = 'ISC_REQ_SEQUENCE_DETECT, ISC_REQ_REPLAY_DETECT, ISC_REQ_CONFIDENTIALITY, ISC_REQ_ALLOCATE_MEMORY, ISC_REQ_STREAM'
+    }
+
+    if ($sRes) {
+        # On subsequent calls the input buffer contains the SECBUFFER_TOKEN
+        # from the server plus a SECBUFFER_EMPTY.
+        $stepParams.InputBuffer = @(
+            $sRes.Buffers[0]
+            'SECBUFFER_EMPTY'
+        )
+
+        # The output buffer contains the token, an alert buffer and finally
+        # an empty buffer.
+        $stepParams.OutputBuffer = @(
+            'SECBUFFER_TOKEN',
+            'SECBUFFER_ALERT',
+            'SECBUFFER_EMPTY'
+        )
+    }
+    else {
+        # On the first call the input buffer must not be set. The output buffer
+        # must be a SECBUFFER_EMPTY which SSPI will fill.
+        $stepParams.OutputBuffer = 'SECBUFFER_EMPTY'
+    }
+
+    $cRes = Step-InitSecContext @stepParams
+
+    # First call will be ContinueNeeded. The second call will be Ok but the
+    # client may still need to process more data from the server. Only exit
+    # the authentication loop when there's no more data to send to the server
+    if ($cRes.Buffers[0].Length -eq 0) {
+        break
+    }
+
+    # The server's input buffer is the SECBUFFER_TOKEN from the client and a
+    # SECBUFFER_EMPTY token. The output buffer is simply the SECBUFFER_TOKEN.
+    $stepParams = @{
+        Context = $sCtx
+        ContextReq = 'ASC_REQ_ALLOCATE_MEMORY'
+        InputBuffer = @(
+            $cRes.Buffers[0]
+            'SECBUFFER_EMPTY'
+        )
+        OutputBuffer = 'SECBUFFER_TOKEN'
+    }
+    $sRes = Step-AcceptSecContext @stepParams
+
+    # Exit the loop if there's no more data to send to the server
+    if ($sRes.Buffers[0].Length -eq 0) {
+        break
+    }
+}
+
+if ($cRes.Result -ne [PSSPI.SecContextStatus]::Ok) {
+    throw "Client context is not complete and there's no more server data: $($cRes.Result)"
+}
+if ($sRes.Result -ne [PSSPI.SecContextStatus]::Ok) {
+    throw "Server context is not complete and there's no more client data: $($sRes.Result)"
+}
+```

--- a/module/PSSPI.psd1
+++ b/module/PSSPI.psd1
@@ -14,7 +14,7 @@
     RootModule             = 'bin/netcoreapp3.1/PSSPI.dll'
 
     # Version number of this module.
-    ModuleVersion          = '0.2.0'
+    ModuleVersion          = '0.3.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -71,11 +71,16 @@
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
     CmdletsToExport        = @(
+        'Get-SchannelCredential'
+        'Get-SCHCredential'
+        'Get-SecContextCipherInfo'
         'Get-SSPICredential'
         'Get-SSPIPackage'
-        'New-ChannelBindingBuffer',
+        'New-ChannelBindingBuffer'
+        'New-CryptoSetting'
         'New-SecBuffer'
         'New-SecContext'
+        'New-TlsParameter'
         'Set-KdcProxy'
         'Step-AcceptSecContext'
         'Step-InitSecContext'

--- a/requirements-dev.psd1
+++ b/requirements-dev.psd1
@@ -1,6 +1,6 @@
 @{
-    InvokeBuild      = '5.9.10'
-    Pester           = '5.3.1'
+    InvokeBuild      = '5.10.1'
+    Pester           = '5.3.3'
     platyPS          = '0.14.2'
-    PSScriptAnalyzer = '1.20.0'
+    PSScriptAnalyzer = '1.21.0'
 }

--- a/src/AuthData.cs
+++ b/src/AuthData.cs
@@ -21,6 +21,8 @@ public class WinNTAuthIdentity : ICredentialIdentity
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     private struct SEC_WINNT_AUTH_IDENTITY_EXW
     {
+        public const int SEC_WINNT_AUTH_IDENTITY_VERSION = 0x200;
+
         public UInt32 Version;
         public UInt32 Length;
         public unsafe char* User;
@@ -71,7 +73,7 @@ public class WinNTAuthIdentity : ICredentialIdentity
                 {
                     SEC_WINNT_AUTH_IDENTITY_EXW authData = new()
                     {
-                        Version = 0x200,  // SEC_WINNT_AUTH_IDENTITY_VERSION
+                        Version = SEC_WINNT_AUTH_IDENTITY_EXW.SEC_WINNT_AUTH_IDENTITY_VERSION,
                         Length = (uint)Marshal.SizeOf<SEC_WINNT_AUTH_IDENTITY_EXW>(),
                         User = userPtr,
                         UserLength = (uint)(Username?.Length ?? 0),

--- a/src/Commands/CryptoSetting.cs
+++ b/src/Commands/CryptoSetting.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Management.Automation;
+using System.Management.Automation.Language;
+
+namespace PSSPI.Commands;
+
+[Cmdlet(
+    VerbsCommon.New, "CryptoSetting"
+)]
+[OutputType(typeof(CryptoSetting))]
+public class NewCryptoSetting : PSCmdlet
+{
+    [Parameter(Mandatory = true)]
+    public SchannelCryptoUsage Usage { get; set; }
+
+    [Parameter(Mandatory = true)]
+    [ArgumentCompleter(typeof(AlgorithmCompleter))]
+    public string Algorithm { get; set; } = "";
+
+    [Parameter()]
+    [ArgumentCompleter(typeof(ChainingModeCompleter))]
+    public string[] ChainingMode { get; set; } = Array.Empty<string>();
+
+    [Parameter()]
+    public int MinBitLength { get; set; }
+
+    [Parameter()]
+    public int MaxBitLength { get; set; }
+
+    protected override void EndProcessing()
+    {
+        if (ChainingMode.Length > 16)  // SCH_CRED_MAX_SUPPORTED_CHAINING_MODES
+        {
+            ErrorRecord err = new(
+                new ArgumentException("Crypto Settings can not have more than 16 chaining modes specified"),
+                "TooManyChainingModes",
+                ErrorCategory.InvalidArgument,
+                ChainingMode
+            );
+            WriteError(err);
+            return;
+        }
+
+        WriteObject(new CryptoSetting(Usage, Algorithm, ChainingMode, MinBitLength, MaxBitLength));
+    }
+
+    private class AlgorithmCompleter : IArgumentCompleter
+    {
+        public IEnumerable<CompletionResult>? CompleteArgument(string commandName, string parameterName,
+                string wordToComplete, CommandAst commandAst, IDictionary fakeBoundParameters)
+        {
+            if (String.IsNullOrWhiteSpace(wordToComplete))
+                wordToComplete = "";
+
+            SchannelCryptoUsage? usage = null;
+            if (fakeBoundParameters.Contains("Usage"))
+            {
+                object? rawUsage = fakeBoundParameters["Usage"];
+                if (rawUsage is SchannelCryptoUsage parsedUsage)
+                {
+                    usage = parsedUsage;
+                }
+                else if (Enum.TryParse<SchannelCryptoUsage>(rawUsage?.ToString() ?? "", true,
+                    out var cryptoUsage))
+                {
+                    usage = cryptoUsage;
+                }
+            }
+
+            // https://learn.microsoft.com/en-us/windows/win32/api/schannel/ns-schannel-crypto_settings
+            // Most examples from the above but some are based on the list of TLS ciphers supported by MS.
+            HashSet<string> kexchValues = new() { "DH", "ECDH", "PSK", "RSA" };
+            HashSet<string> sigValues = new() { "DSA", "DSS", "ECDSA", "EXPORT", "EXPORT1024", "RSA" };
+            HashSet<string> cipherValues = new() { "3DES", "AES", "DES", "CHACHA20_POLY1305", "RC4" };
+            HashSet<string> digestValues = new() { "MD5", "SHA1", "SHA256", "SHA384" };
+            HashSet<string> certSigValues = new() { "DSA", "ECDSA", "RSA", "SHA1", "SHA256" };
+
+            HashSet<string> availableOptions = new();
+            if (usage == null)
+            {
+                availableOptions.UnionWith(kexchValues);
+                availableOptions.UnionWith(sigValues);
+                availableOptions.UnionWith(cipherValues);
+                availableOptions.UnionWith(digestValues);
+                availableOptions.UnionWith(certSigValues);
+            }
+            else if (usage == SchannelCryptoUsage.KeyExchange)
+            {
+                availableOptions = kexchValues;
+            }
+            else if (usage == SchannelCryptoUsage.Signature)
+            {
+                availableOptions = sigValues;
+            }
+            else if (usage == SchannelCryptoUsage.Cipher)
+            {
+                availableOptions = cipherValues;
+            }
+            else if (usage == SchannelCryptoUsage.Digest)
+            {
+                availableOptions = digestValues;
+            }
+            else if (usage == SchannelCryptoUsage.CertSig)
+            {
+                availableOptions = certSigValues;
+            }
+
+            foreach (string option in availableOptions)
+            {
+                if (option.StartsWith(wordToComplete, true, CultureInfo.InvariantCulture))
+                {
+                    yield return new CompletionResult(option);
+                }
+            }
+        }
+    }
+
+    private class ChainingModeCompleter : IArgumentCompleter
+    {
+        public IEnumerable<CompletionResult>? CompleteArgument(string commandName, string parameterName,
+                string wordToComplete, CommandAst commandAst, IDictionary fakeBoundParameters)
+        {
+            if (String.IsNullOrWhiteSpace(wordToComplete))
+                wordToComplete = "";
+
+            // https://learn.microsoft.com/en-us/windows/win32/seccng/cng-property-identifiers
+            // BCRYPT_CHAINING_MODE
+            HashSet<string> availableOptions = new() {
+                "ChainingModeCBC",
+                "ChainingModeCCM",
+                "ChainingModeCFB",
+                "ChainingModeECB",
+                "ChainingModeGCM",
+                "ChainingModeN/A",
+            };
+
+            foreach (string option in availableOptions)
+            {
+                if (option.StartsWith(wordToComplete, true, CultureInfo.InvariantCulture))
+                {
+                    yield return new CompletionResult(option);
+                }
+            }
+        }
+    }
+}

--- a/src/Commands/SChannelCredential.cs
+++ b/src/Commands/SChannelCredential.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Management.Automation;
+using System.Security.Cryptography.X509Certificates;
+
+namespace PSSPI.Commands;
+
+[Cmdlet(
+    VerbsCommon.Get, "SchannelCredential"
+)]
+[OutputType(typeof(Credential))]
+public class GetSchannelCredential : PSCmdlet
+{
+    [Parameter()]
+    public CredentialUse CredentialUse { get; set; } = CredentialUse.SECPKG_CRED_OUTBOUND;
+
+    [Parameter()]
+    [ValidateNotNullOrEmpty]
+    public X509Certificate[] Certificate { get; set; } = Array.Empty<X509Certificate>();
+
+    [Parameter()]
+    public X509Store? RootStore { get; set; }
+
+    [Parameter()]
+    public int SessionLifespanMS { get; set; } = 0;
+
+    [Parameter()]
+    public SchannelCredFlags Flags { get; set; } = SchannelCredFlags.None;
+
+    [Parameter()]
+    [ValidateNotNullOrEmpty()]
+    public AlgorithmId[] SupportedAlgs { get; set; } = Array.Empty<AlgorithmId>();
+
+    [Parameter()]
+    public SchannelProtocols Protocols { get; set; } = SchannelProtocols.SP_PROT_NONE;
+
+    [Parameter()]
+    public int MinimumCipherStrength { get; set; } = 0;
+
+    [Parameter()]
+    public int MaximumCipherStrength { get; set; } = 0;
+
+    protected override void EndProcessing()
+    {
+        if ((CredentialUse & CredentialUse.SECPKG_CRED_INBOUND) != 0 && Certificate.Length == 0)
+        {
+            ErrorRecord err = new(
+                new ArgumentException("At least one certificate must be specified when using SECPKG_CRED_INBOUND"),
+                "SchannelCredentialInboundNoCertificate",
+                ErrorCategory.InvalidData,
+                null);
+            WriteError(err);
+            return;
+        }
+
+        const string package = "Microsoft Unified Security Protocol Provider";
+        SchannelCred authData = new(
+            certificates: Certificate,
+            rootStore: RootStore,
+            sessionLifespanMS: SessionLifespanMS,
+            flags: Flags,
+            supportedAlgs: SupportedAlgs,
+            enabledProtocols: Protocols,
+            minimumCipherStrength: MinimumCipherStrength,
+            maximumCipherStrength: MaximumCipherStrength);
+
+        try
+        {
+            WriteObject(SSPI.AcquireCredentialsHandle(null, package, CredentialUse, authData));
+        }
+        catch (SspiException e)
+        {
+            WriteError(new ErrorRecord(e, "NativeException", ErrorCategory.InvalidArgument, package));
+        }
+    }
+}
+
+
+[Cmdlet(
+    VerbsCommon.Get, "SCHCredential"
+)]
+[OutputType(typeof(Credential))]
+public class GetSCHCredential : PSCmdlet
+{
+    [Parameter()]
+    public CredentialUse CredentialUse { get; set; } = CredentialUse.SECPKG_CRED_OUTBOUND;
+
+    [Parameter()]
+    [ValidateNotNullOrEmpty]
+    public X509Certificate[] Certificate { get; set; } = Array.Empty<X509Certificate>();
+
+    [Parameter()]
+    public X509Store? RootStore { get; set; }
+
+    [Parameter()]
+    public int SessionLifespanMS { get; set; } = 0;
+
+    [Parameter()]
+    public SchannelCredFlags Flags { get; set; } = SchannelCredFlags.None;
+
+    [Parameter()]
+    [ValidateNotNullOrEmpty]
+    public TlsParameter[] TlsParameter { get; set; } = Array.Empty<TlsParameter>();
+
+
+    protected override void EndProcessing()
+    {
+        bool hadError = false;
+        if (TlsParameter.Length > 16)  // SCH_CRED_MAX_SUPPORTED_PARAMETERS
+        {
+            ErrorRecord err = new(
+                new ArgumentException("Schannel credential can not have more than 16 TLS Parameters"),
+                "TooManyTlsParameters",
+                ErrorCategory.InvalidArgument,
+                TlsParameter
+            );
+            WriteError(err);
+            hadError = true;
+        }
+        if ((CredentialUse & CredentialUse.SECPKG_CRED_INBOUND) != 0 && Certificate.Length == 0)
+        {
+            ErrorRecord err = new(
+                new ArgumentException("At least one certificate must be specified when using SECPKG_CRED_INBOUND"),
+                "SCHCredentialInboundNoCertificate",
+                ErrorCategory.InvalidData,
+                null);
+            WriteError(err);
+            hadError = true;
+        }
+        if (hadError)
+        {
+            return;
+        }
+
+        const string package = "Microsoft Unified Security Protocol Provider";
+        SCHCredential authData = new(
+            certificates: Certificate,
+            rootStore: RootStore,
+            sessionLifespanMS: SessionLifespanMS,
+            flags: Flags,
+            tlsParameters: TlsParameter);
+
+        try
+        {
+            WriteObject(SSPI.AcquireCredentialsHandle(null, package, CredentialUse, authData));
+        }
+        catch (SspiException e)
+        {
+            WriteError(new ErrorRecord(e, "NativeException", ErrorCategory.InvalidArgument, package));
+        }
+    }
+}

--- a/src/Commands/SecContextCipherInfo.cs
+++ b/src/Commands/SecContextCipherInfo.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Management.Automation;
+
+namespace PSSPI.Commands;
+
+[Cmdlet(
+    VerbsCommon.Get, "SecContextCipherInfo"
+)]
+[OutputType(typeof(CipherInfo))]
+public class GetSecContextCipherInfo : PSCmdlet
+{
+    [Parameter(
+        Mandatory = true,
+        ValueFromPipeline = true,
+        ValueFromPipelineByPropertyName = true
+    )]
+    public SecurityContext[] Context { get; set; } = Array.Empty<SecurityContext>();
+
+    protected override void ProcessRecord()
+    {
+        foreach (SecurityContext context in Context)
+        {
+            string cipherSuite;
+            string cipher;
+
+            Span<Helpers.SecPkgContext_CipherInfo> ci = new(new Helpers.SecPkgContext_CipherInfo[1]);
+            unsafe
+            {
+                fixed (Helpers.SecPkgContext_CipherInfo* ciPtr = ci)
+                {
+                    SSPI.QueryContextAttributes(context.SafeHandle, SecPkgAttribute.SECPKG_ATTR_CIPHER_INFO, (void*)ciPtr);
+                }
+
+                fixed (char* cipherSuitePtr = ci[0].szCipherSuite)
+                fixed (char* cipherPtr = ci[0].szCipher)
+                {
+                    cipherSuite = new(cipherSuitePtr);
+                    cipher = new(cipherPtr);
+                }
+            }
+
+            WriteObject(new CipherInfo(
+                (TlsProtocol)ci[0].dwProtocol,
+                cipherSuite,
+                cipher,
+                ci[0].dwCipherLen
+                ));
+        }
+    }
+}
+
+public class CipherInfo
+{
+    public TlsProtocol Protocol { get; }
+    public string CipherSuite { get; }
+    public string Cipher { get; }
+    public int CipherLength { get; }
+
+    public CipherInfo(TlsProtocol protocol, string cipherSuite, string cipher, int cipherLength)
+    {
+        Protocol = protocol;
+        CipherSuite = cipherSuite;
+        Cipher = cipher;
+        CipherLength = cipherLength;
+    }
+}
+
+public enum TlsProtocol
+{
+    TLS1_0 = 0x0301,
+    TLS1_1 = 0x0302,
+    TLS1_2 = 0x0303,
+    TLS1_3 = 0x0304,
+}

--- a/src/Commands/TlsParameter.cs
+++ b/src/Commands/TlsParameter.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Management.Automation;
+
+namespace PSSPI.Commands;
+
+[Cmdlet(
+    VerbsCommon.New, "TlsParameter"
+)]
+[OutputType(typeof(TlsParameter))]
+public class NewTlsParameter : PSCmdlet
+{
+    [Parameter()]
+    public string[] AlpnId { get; set; } = Array.Empty<string>();
+
+    [Parameter()]
+    public SchannelProtocols DisabledProtocol { get; set; }
+
+    [Parameter()]
+    public CryptoSetting[] DisabledCrypto { get; set; } = Array.Empty<CryptoSetting>();
+
+    [Parameter()]
+    public SwitchParameter Optional { get; set; }
+
+    protected override void EndProcessing()
+    {
+        bool hadError = false;
+        if (AlpnId.Length > 16)  // SCH_CRED_MAX_SUPPORTED_ALPN_IDS
+        {
+            ErrorRecord err = new(
+                new ArgumentException("TLS Parameters can not have more than 16 ALPN Ids specified"),
+                "TooManyAlpnIds",
+                ErrorCategory.InvalidArgument,
+                AlpnId
+            );
+            WriteError(err);
+            hadError = true;
+        }
+
+        if (DisabledCrypto.Length > 16)  // SCH_CRED_MAX_SUPPORTED_CRYPTO_SETTINGS
+        {
+            ErrorRecord err = new(
+                new ArgumentException("TLS Parameters can not have more than 16 crypto settings specified"),
+                "TooManyCryptoSettings",
+                ErrorCategory.InvalidArgument,
+                DisabledCrypto
+            );
+            WriteError(err);
+            hadError = true;
+        }
+
+        if (hadError)
+        {
+            return;
+        }
+
+        WriteObject(new TlsParameter(AlpnId, DisabledProtocol, DisabledCrypto, Optional));
+    }
+}

--- a/src/SSPI.cs
+++ b/src/SSPI.cs
@@ -62,6 +62,28 @@ internal static class Helpers
         public UInt16 ClientTlsCredLength;
     }
 
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    public struct SecPkgContext_CipherInfo
+    {
+        private const int SZ_ALG_MAX_SIZE = 64;
+
+        public int dwVersion;
+        public int dwProtocol;
+        public int dwCipherSuite;
+        public int dwBaseCipherSuite;
+        public unsafe fixed char szCipherSuite[SZ_ALG_MAX_SIZE];
+        public unsafe fixed char szCipher[SZ_ALG_MAX_SIZE];
+        public int dwCipherLen;
+        public int dwCipherBlockLen;
+        public unsafe fixed char szHash[SZ_ALG_MAX_SIZE];
+        public int dwHashLen;
+        public unsafe fixed char szExchange[SZ_ALG_MAX_SIZE];
+        public int dwMinExchangeLen;
+        public int dwMaxExchangeLen;
+        public unsafe fixed char szCertificate[SZ_ALG_MAX_SIZE];
+        public int dwKeyType;
+    }
+
     [StructLayout(LayoutKind.Sequential)]
     public struct SecPkgContext_Sizes
     {
@@ -168,10 +190,10 @@ internal static class SSPI
         UInt32 cbBuffer);
 
     [DllImport("Secur32.dll", EntryPoint = "QueryContextAttributes")]
-    private static extern Int32 QueryContextAttributesNative(
+    private unsafe static extern Int32 QueryContextAttributesNative(
         SafeSspiContextHandle phContext,
         SecPkgAttribute ulAttribute,
-        IntPtr pBuffer);
+        void* pBuffer);
 
     [DllImport("Secur32.dll", CharSet = CharSet.Unicode)]
     private static extern Int32 QuerySecurityPackageInfoW(
@@ -371,7 +393,7 @@ internal static class SSPI
         {
             unsafe
             {
-                ReadOnlySpan<Helpers.SecPkgInfoW> packages = new (info.ToPointer(), (int)count);
+                ReadOnlySpan<Helpers.SecPkgInfoW> packages = new(info.ToPointer(), (int)count);
                 return packages.ToArray().Select((p) => new SecPackageInfo(p)).ToArray();
             }
         }
@@ -486,7 +508,7 @@ internal static class SSPI
     /// <param name="buffer">The buffer that will store the queried value.</param>
     /// <exception cref="SspiException">Failure trying to query the requested value.</exception>
     /// <see href="https://docs.microsoft.com/en-us/windows/win32/secauthn/querycontextattributes--general">QueryContextAttributes</see>
-    public static void QueryContextAttributes(SafeSspiContextHandle context, SecPkgAttribute attribute, IntPtr buffer)
+    public unsafe static void QueryContextAttributes(SafeSspiContextHandle context, SecPkgAttribute attribute, void* buffer)
     {
         int res = QueryContextAttributesNative(context, attribute, buffer);
         if (res != 0)
@@ -911,6 +933,44 @@ public enum SecPkgAttribute : uint
     SECPKG_ATTR_APPLICATION_PROTOCOL = 35,
     SECPKG_ATTR_NEGOTIATED_TLS_EXTENSIONS = 36,
     SECPKG_ATTR_IS_LOOPBACK = 37,
+    SECPKG_ATTR_ISSUER_LIST = 0x50,
+    SECPKG_ATTR_REMOTE_CRED = 0x51,
+    SECPKG_ATTR_LOCAL_CRED = 0x52,
+    SECPKG_ATTR_REMOTE_CERT_CONTEXT = 0x53,
+    SECPKG_ATTR_LOCAL_CERT_CONTEXT = 0x54,
+    SECPKG_ATTR_ROOT_STORE = 0x55,
+    SECPKG_ATTR_SUPPORTED_ALGS = 0x56,
+    SECPKG_ATTR_CIPHER_STRENGTHS = 0x57,
+    SECPKG_ATTR_SUPPORTED_PROTOCOLS = 0x58,
+    SECPKG_ATTR_ISSUER_LIST_EX = 0x59,
+    SECPKG_ATTR_CONNECTION_INFO = 0x5a,
+    SECPKG_ATTR_EAP_KEY_BLOCK = 0x5b,
+    SECPKG_ATTR_MAPPED_CRED_ATTR = 0x5c,
+    SECPKG_ATTR_SESSION_INFO = 0x5d,
+    SECPKG_ATTR_APP_DATA = 0x5e,
+    SECPKG_ATTR_REMOTE_CERTIFICATES = 0x5F,
+    SECPKG_ATTR_CLIENT_CERT_POLICY = 0x60,
+    SECPKG_ATTR_CC_POLICY_RESULT = 0x61,
+    SECPKG_ATTR_USE_NCRYPT = 0x62,
+    SECPKG_ATTR_LOCAL_CERT_INFO = 0x63,
+    SECPKG_ATTR_CIPHER_INFO = 0x64,
+    SECPKG_ATTR_EAP_PRF_INFO = 0x65,
+    SECPKG_ATTR_SUPPORTED_SIGNATURES = 0x66,
+    SECPKG_ATTR_REMOTE_CERT_CHAIN = 0x67,
+    SECPKG_ATTR_UI_INFO = 0x68,
+    SECPKG_ATTR_EARLY_START = 0x69,
+    SECPKG_ATTR_KEYING_MATERIAL_INFO = 0x6a,
+    SECPKG_ATTR_KEYING_MATERIAL = 0x6b,
+    SECPKG_ATTR_SRTP_PARAMETERS = 0x6c,
+    SECPKG_ATTR_TOKEN_BINDING = 0x6d,
+    SECPKG_ATTR_CONNECTION_INFO_EX = 0x6e,
+    SECPKG_ATTR_KEYING_MATERIAL_TOKEN_BINDING = 0x6f,
+    SECPKG_ATTR_KEYING_MATERIAL_INPROC = 0x70,
+    SECPKG_ATTR_CERT_CHECK_RESULT = 0x71,
+    SECPKG_ATTR_CERT_CHECK_RESULT_INPROC = 0x72,
+    SECPKG_ATTR_SESSION_TICKET_KEYS = 0x73,
+    SECPKG_ATTR_SERIALIZED_REMOTE_CERT_CONTEXT_INPROC = 0x74,
+    SECPKG_ATTR_SERIALIZED_REMOTE_CERT_CONTEXT = 0x75,
 }
 
 public enum TargetDataRep : uint

--- a/src/SchannelCred.cs
+++ b/src/SchannelCred.cs
@@ -1,0 +1,618 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography.X509Certificates;
+
+namespace PSSPI;
+
+public class SchannelCred : ICredentialIdentity
+{
+    [StructLayout(LayoutKind.Sequential)]
+    private struct SCHANNEL_CRED
+    {
+        public const int SCHANNEL_CRED_VERSION = 0x4;
+
+        public int dwVersion;
+        public int cCreds;
+        public unsafe void* paCred;
+        public IntPtr hRootStore;
+        public int cMappers;
+        public IntPtr aphMappers;
+        public int cSupportedAlgs;
+        public unsafe int* palgSupportedAlgs;
+        public SchannelProtocols grbitEnabledProtocols;
+        public int dwMinimumCipherStrength;
+        public int dwMaximumCipherStream;
+        public int dwSessionLifespan;
+        public SchannelCredFlags dwFlags;
+        public SchannelCredFormat dwCredFormat;
+    }
+
+    public X509Certificate[] Certificates { get; }
+    public X509Store? RootStore { get; }
+    public int SessionLifeSpanMS { get; }
+    public SchannelCredFlags Flags { get; }
+    public AlgorithmId[] SupportedAlgs { get; }
+    public SchannelProtocols EnabledProtocols { get; }
+    public int MinimumCipherStrength { get; }
+    public int MaximumCipherStrength { get; }
+
+    public SchannelCred(X509Certificate[]? certificates = null, X509Store? rootStore = null, int sessionLifespanMS = 0,
+        SchannelCredFlags flags = SchannelCredFlags.None, AlgorithmId[]? supportedAlgs = null,
+        SchannelProtocols enabledProtocols = SchannelProtocols.SP_PROT_NONE, int minimumCipherStrength = 0,
+        int maximumCipherStrength = 0)
+    {
+        Certificates = certificates ?? Array.Empty<X509Certificate>();
+        RootStore = rootStore;
+        SessionLifeSpanMS = sessionLifespanMS;
+        Flags = flags;
+        SupportedAlgs = supportedAlgs ?? Array.Empty<AlgorithmId>();
+        EnabledProtocols = enabledProtocols;
+        MinimumCipherStrength = minimumCipherStrength;
+        MaximumCipherStrength = maximumCipherStrength;
+    }
+
+    int ICredentialIdentity.AcquireCredentialsHandle(string? principal, string package, CredentialUse usage,
+        SafeSspiCredentialHandle credential, out Helpers.SECURITY_INTEGER expiry)
+    {
+        unsafe
+        {
+            Span<IntPtr> certContexts = Certificates.Select(c => c.Handle).ToArray().AsSpan();
+
+            fixed (void* certContextPtr = certContexts)
+            fixed (AlgorithmId* algsPtr = SupportedAlgs)
+            {
+                SCHANNEL_CRED authData = new()
+                {
+                    dwVersion = SCHANNEL_CRED.SCHANNEL_CRED_VERSION,
+                    cCreds = Certificates.Length,
+                    paCred = certContextPtr,
+                    hRootStore = RootStore?.StoreHandle ?? IntPtr.Zero,
+                    cMappers = 0,
+                    aphMappers = IntPtr.Zero,
+                    cSupportedAlgs = SupportedAlgs?.Length ?? 0,
+                    palgSupportedAlgs = (int*)algsPtr,
+                    grbitEnabledProtocols = EnabledProtocols,
+                    dwMinimumCipherStrength = MinimumCipherStrength,
+                    dwMaximumCipherStream = MaximumCipherStrength,
+                    dwSessionLifespan = SessionLifeSpanMS,
+                    dwFlags = Flags,
+                    dwCredFormat = SchannelCredFormat.SCH_CRED_FORMAT_CERT_CONTEXT,
+                };
+                return SSPI.AcquireCredentialsHandleW(
+                    principal,
+                    package,
+                    usage,
+                    IntPtr.Zero,
+                    (void*)&authData,
+                    IntPtr.Zero,
+                    IntPtr.Zero,
+                    credential,
+                    out expiry);
+            }
+        }
+    }
+}
+
+public class SCHCredential : ICredentialIdentity
+{
+    [StructLayout(LayoutKind.Sequential)]
+    private struct SCH_CREDENTIALS
+    {
+        public const int SCH_CREDENTIALS_VERSION = 0x5;
+
+        public int dwVersion;
+        public SchannelCredFormat dwCredFormat;
+        public int cCreds;
+        public unsafe void* paCred;
+        public IntPtr hRootStore;
+        public int cMappers;
+        public IntPtr aphMappers;
+        public int dwSessionLifespan;
+        public SchannelCredFlags dwFlags;
+        public int cTlsParameters;
+        public unsafe TLS_PARAMETERS* pTlsParameters;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct CRYPTO_SETTINGS
+    {
+        public SchannelCryptoUsage eAlgorithmUsage;
+        public UNICODE_STRING strCngAlgId;
+        public int cChainingModes;
+        public unsafe UNICODE_STRING* rgstrChainingModes;
+        public int dwMinBitLength;
+        public int dwMaxBitLength;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct TLS_PARAMETERS
+    {
+        public int cAlpnIds;
+        public unsafe UNICODE_STRING* rgstrAlpnIds;
+        public SchannelProtocols grbitDisabledProtocols;
+        public int cDisabledCrypto;
+        public unsafe CRYPTO_SETTINGS* pDisabledCrypto;
+        public TLS_PARAMETERS.Flags dwFlags;
+
+        [Flags]
+        public enum Flags
+        {
+            None = 0x00000000,
+            TLS_PARAMS_OPTIONAL = 0x00000001,
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct UNICODE_STRING
+    {
+        public UInt16 Length;
+        public UInt16 MaximumLength;
+        public IntPtr Buffer;
+    }
+
+    public X509Certificate[] Certificates { get; }
+    public X509Store? RootStore { get; }
+    public int SessionLifeSpanMS { get; }
+    public SchannelCredFlags Flags { get; }
+    public TlsParameter[] TlsParameters { get; }
+
+    public SCHCredential(X509Certificate[]? certificates = null, X509Store? rootStore = null, int sessionLifespanMS = 0,
+        SchannelCredFlags flags = SchannelCredFlags.None, TlsParameter[]? tlsParameters = null)
+    {
+        Certificates = certificates ?? Array.Empty<X509Certificate>();
+        RootStore = rootStore;
+        SessionLifeSpanMS = sessionLifespanMS;
+        Flags = flags;
+        TlsParameters = tlsParameters ?? Array.Empty<TlsParameter>();
+    }
+
+    int ICredentialIdentity.AcquireCredentialsHandle(string? principal, string package, CredentialUse usage,
+        SafeSspiCredentialHandle credential, out Helpers.SECURITY_INTEGER expiry)
+    {
+        Span<TLS_PARAMETERS> tlsParameters = stackalloc TLS_PARAMETERS[TlsParameters.Length];
+
+        List<IntPtr> buffers = new();
+        try
+        {
+            unsafe
+            {
+                for (int i = 0; i < TlsParameters.Length; i++)
+                {
+                    TlsParameter param = TlsParameters[i];
+
+                    int alpnLength = param.AlpnIds.Length;
+                    if (alpnLength > 0)
+                    {
+                        tlsParameters[i].cAlpnIds = alpnLength;
+
+                        buffers.Add(Marshal.AllocHGlobal(Marshal.SizeOf<UNICODE_STRING>() * alpnLength));
+                        tlsParameters[i].rgstrAlpnIds = (UNICODE_STRING*)buffers[^1];
+
+                        Span<UNICODE_STRING> alpnStructs = new(tlsParameters[i].rgstrAlpnIds, alpnLength);
+                        for (int j = 0; j < alpnLength; j++)
+                        {
+                            PopulateUnicodeString(ref alpnStructs[j], param.AlpnIds[j], buffers);
+                        }
+                    }
+                    else
+                    {
+                        tlsParameters[i].cAlpnIds = 0;
+                        tlsParameters[i].rgstrAlpnIds = null;
+                    }
+
+                    tlsParameters[i].grbitDisabledProtocols = param.DisabledProtocols;
+
+                    int cryptosLength = param.DisabledCryptos.Length;
+                    if (cryptosLength > 0)
+                    {
+                        tlsParameters[i].cDisabledCrypto = cryptosLength;
+
+                        buffers.Add(Marshal.AllocHGlobal(Marshal.SizeOf<CRYPTO_SETTINGS>() * cryptosLength));
+                        tlsParameters[i].pDisabledCrypto = (CRYPTO_SETTINGS*)buffers[^1];
+
+                        Span<CRYPTO_SETTINGS> cryptoStructs = new(tlsParameters[i].pDisabledCrypto, cryptosLength);
+                        for (int j = 0; j < cryptosLength; j++)
+                        {
+                            PopulateCryptoSettings(ref cryptoStructs[j], param.DisabledCryptos[j], buffers);
+                        }
+                    }
+                    else
+                    {
+                        tlsParameters[i].cDisabledCrypto = 0;
+                        tlsParameters[i].pDisabledCrypto = null;
+                    }
+
+                    tlsParameters[i].dwFlags = param.Optional
+                        ? TLS_PARAMETERS.Flags.TLS_PARAMS_OPTIONAL
+                        : TLS_PARAMETERS.Flags.None;
+                }
+
+                Span<IntPtr> certContexts = Certificates.Select(c => c.Handle).ToArray().AsSpan();
+
+                fixed (void* certContextPtr = certContexts)
+                fixed (TLS_PARAMETERS* tlsParameterPtr = tlsParameters)
+                {
+                    SCH_CREDENTIALS authData = new()
+                    {
+                        dwVersion = SCH_CREDENTIALS.SCH_CREDENTIALS_VERSION,
+                        dwCredFormat = SchannelCredFormat.SCH_CRED_FORMAT_CERT_CONTEXT,
+                        cCreds = Certificates.Length,
+                        paCred = certContextPtr,
+                        hRootStore = RootStore?.StoreHandle ?? IntPtr.Zero,
+                        cMappers = 0,
+                        aphMappers = IntPtr.Zero,
+                        dwSessionLifespan = SessionLifeSpanMS,
+                        dwFlags = Flags,
+                        cTlsParameters = tlsParameters.Length,
+                        pTlsParameters = tlsParameterPtr,
+                    };
+                    return SSPI.AcquireCredentialsHandleW(
+                        principal,
+                        package,
+                        usage,
+                        IntPtr.Zero,
+                        (void*)&authData,
+                        IntPtr.Zero,
+                        IntPtr.Zero,
+                        credential,
+                        out expiry);
+                }
+            }
+        }
+        finally
+        {
+            foreach (IntPtr buffer in buffers)
+            {
+                Marshal.FreeHGlobal(buffer);
+            }
+        }
+    }
+
+    private static void PopulateUnicodeString(ref UNICODE_STRING uniString, string value, List<IntPtr> buffers)
+    {
+        buffers.Add(Marshal.StringToHGlobalUni(value));
+        uniString.Length = (UInt16)(value.Length * 2);
+        uniString.MaximumLength = uniString.Length;
+        uniString.Buffer = buffers[^1];
+    }
+
+    private unsafe static void PopulateCryptoSettings(ref CRYPTO_SETTINGS settings, CryptoSetting value, List<IntPtr> buffers)
+    {
+        settings.eAlgorithmUsage = value.Usage;
+        PopulateUnicodeString(ref settings.strCngAlgId, value.Algorithm, buffers);
+
+        int chainingLength = value.ChainingModes.Length;
+        if (chainingLength > 0)
+        {
+            settings.cChainingModes = chainingLength;
+
+            buffers.Add(Marshal.AllocHGlobal(Marshal.SizeOf<UNICODE_STRING>() * chainingLength));
+            settings.rgstrChainingModes = (UNICODE_STRING*)buffers[^1];
+
+            Span<UNICODE_STRING> chainingStructs = new(settings.rgstrChainingModes, chainingLength);
+            for (int i = 0; i < chainingLength; i++)
+            {
+                PopulateUnicodeString(ref chainingStructs[i], value.ChainingModes[i], buffers);
+            }
+        }
+        else
+        {
+            settings.cChainingModes = 0;
+            settings.rgstrChainingModes = null;
+        }
+
+        settings.dwMinBitLength = value.MinBitLength;
+        settings.dwMaxBitLength = value.MaxBitLength;
+    }
+}
+
+public class CryptoSetting
+{
+    public SchannelCryptoUsage Usage { get; set; }
+
+    public string Algorithm { get; set; }
+
+    public string[] ChainingModes { get; set; } = Array.Empty<string>();
+
+    public int MinBitLength { get; set; }
+
+    public int MaxBitLength { get; set; }
+
+    public CryptoSetting(SchannelCryptoUsage usage, string algorithm, string[] chainingModes, int minBitLength,
+        int maxBitLength)
+    {
+        Usage = usage;
+        Algorithm = algorithm;
+        ChainingModes = chainingModes;
+        MinBitLength = minBitLength;
+        MaxBitLength = maxBitLength;
+    }
+}
+
+public class TlsParameter
+{
+    public string[] AlpnIds { get; set; } = Array.Empty<string>();
+
+    public SchannelProtocols DisabledProtocols { get; set; }
+
+    public CryptoSetting[] DisabledCryptos { get; set; }
+
+    public bool Optional { get; set; }
+
+    public TlsParameter(string[] alpnIds, SchannelProtocols disabledProtocols, CryptoSetting[] disabledCryptos,
+        bool optional)
+    {
+        AlpnIds = alpnIds;
+        DisabledProtocols = disabledProtocols;
+        DisabledCryptos = disabledCryptos;
+        Optional = optional;
+    }
+}
+
+public enum AlgorithmId
+{
+    // Algorithm Classes
+    ALG_CLASS_ANY = 0,
+    ALG_CLASS_SIGNATURE = 1 << 13,
+    ALG_CLASS_MSG_ENCRYPT = 2 << 13,
+    ALG_CLASS_DATA_ENCRYPT = 3 << 13,
+    ALG_CLASS_HASH = 4 << 13,
+    ALG_CLASS_KEY_EXCHANGE = 5 << 13,
+    ALG_CLASS_ALL = 7 << 13,
+
+    // Algorithm Types
+    ALG_TYPE_ANY = 0,
+    ALG_TYPE_DSS = 1 << 9,
+    ALG_TYPE_RSA = 2 << 9,
+    ALG_TYPE_BLOCK = 3 << 9,
+    ALG_TYPE_STREAM = 4 << 9,
+    ALG_TYPE_DH = 5 << 9,
+    ALG_TYPE_SECURECHANNEL = 6 << 9,
+    ALG_TYPE_ECDH = 7 << 9,
+    ALG_TYPE_THIRDPARTY = 8 << 9,
+
+    // Algorithm Sub Ids
+    ALG_SID_ANY = 0,
+
+    // Generic ThirdParty sub-ids
+    ALG_SID_THIRDPARTY_ANY = 0,
+
+    // Some RSA sub-ids
+    ALG_SID_RSA_ANY = 0,
+    ALG_SID_RSA_PKCS = 1,
+    ALG_SID_RSA_MSATWORK = 2,
+    ALG_SID_RSA_ENTRUST = 3,
+    ALG_SID_RSA_PGP = 4,
+
+    // Some DSS sub-ids
+    ALG_SID_DSS_ANY = 0,
+    ALG_SID_DSS_PKCS = 1,
+    ALG_SID_DSS_DMS = 2,
+    ALG_SID_ECDSA = 3,
+
+    // Block cipher sub ids
+    ALG_SID_DES = 1,
+    ALG_SID_3DES = 3,
+    ALG_SID_DESX = 4,
+    ALG_SID_IDEA = 5,
+    ALG_SID_CAST = 6,
+    ALG_SID_SAFERSK64 = 7,
+    ALG_SID_SAFERSK128 = 8,
+    ALG_SID_3DES_112 = 9,
+    ALG_SID_CYLINK_MEK = 12,
+    ALG_SID_RC5 = 13,
+    ALG_SID_AES_128 = 14,
+    ALG_SID_AES_192 = 15,
+    ALG_SID_AES_256 = 16,
+    ALG_SID_AES = 17,
+
+    // Fortezza sub-ids
+    ALG_SID_SKIPJACK = 10,
+    ALG_SID_TEK = 11,
+
+    // RC2 sub-ids
+    ALG_SID_RC2 = 2,
+
+    // Stream cipher sub-ids
+    ALG_SID_RC4 = 1,
+    ALG_SID_SEAL = 2,
+
+    // Diffie-Hellman sub-ids
+    ALG_SID_DH_SANDF = 1,
+    ALG_SID_DH_EPHEM = 2,
+    ALG_SID_AGREED_KEY_ANY = 3,
+    ALG_SID_KEA = 4,
+    ALG_SID_ECDH = 5,
+    ALG_SID_ECDH_EPHEM = 6,
+
+    // Hash sub ids
+    ALG_SID_MD2 = 1,
+    ALG_SID_MD4 = 2,
+    ALG_SID_MD5 = 3,
+    ALG_SID_SHA = 4,
+    ALG_SID_SHA1 = 4,
+    ALG_SID_MAC = 5,
+    ALG_SID_RIPEMD = 6,
+    ALG_SID_RIPEMD160 = 7,
+    ALG_SID_SSL3SHAMD5 = 8,
+    ALG_SID_HMAC = 9,
+    ALG_SID_TLS1PRF = 10,
+    ALG_SID_HASH_REPLACE_OWF = 11,
+    ALG_SID_SHA_256 = 12,
+    ALG_SID_SHA_384 = 13,
+    ALG_SID_SHA_512 = 14,
+    ALG_SID_SSL3_MASTER = 1,
+    ALG_SID_SCHANNEL_MASTER_HASH = 2,
+    ALG_SID_SCHANNEL_MAC_KEY = 3,
+    ALG_SID_PCT1_MASTER = 4,
+    ALG_SID_SSL2_MASTER = 5,
+    ALG_SID_TLS1_MASTER = 6,
+    ALG_SID_SCHANNEL_ENC_KEY = 7,
+    ALG_SID_ECMQV = 1,
+
+    CALG_MD2 = ALG_CLASS_HASH | ALG_TYPE_ANY | ALG_SID_MD2,
+    CALG_MD4 = ALG_CLASS_HASH | ALG_TYPE_ANY | ALG_SID_MD4,
+    CALG_MD5 = ALG_CLASS_HASH | ALG_TYPE_ANY | ALG_SID_MD5,
+    CALG_SHA = ALG_CLASS_HASH | ALG_TYPE_ANY | ALG_SID_SHA,
+    CALG_SHA1 = ALG_CLASS_HASH | ALG_TYPE_ANY | ALG_SID_SHA1,
+    CALG_MAC = ALG_CLASS_HASH | ALG_TYPE_ANY | ALG_SID_MAC,
+    CALG_RSA_SIGN = ALG_CLASS_SIGNATURE | ALG_TYPE_RSA | ALG_SID_RSA_ANY,
+    CALG_DSS_SIGN = ALG_CLASS_SIGNATURE | ALG_TYPE_DSS | ALG_SID_DSS_ANY,
+    CALG_NO_SIGN = ALG_CLASS_SIGNATURE | ALG_TYPE_ANY | ALG_SID_ANY,
+    CALG_RSA_KEYX = ALG_CLASS_KEY_EXCHANGE | ALG_TYPE_RSA | ALG_SID_RSA_ANY,
+    CALG_DES = ALG_CLASS_DATA_ENCRYPT | ALG_TYPE_BLOCK | ALG_SID_DES,
+    CALG_3DES_112 = ALG_CLASS_DATA_ENCRYPT | ALG_TYPE_BLOCK | ALG_SID_3DES_112,
+    CALG_3DES = ALG_CLASS_DATA_ENCRYPT | ALG_TYPE_BLOCK | ALG_SID_3DES,
+    CALG_DESX = ALG_CLASS_DATA_ENCRYPT | ALG_TYPE_BLOCK | ALG_SID_DESX,
+    CALG_RC2 = ALG_CLASS_DATA_ENCRYPT | ALG_TYPE_BLOCK | ALG_SID_RC2,
+    CALG_RC4 = ALG_CLASS_DATA_ENCRYPT | ALG_TYPE_STREAM | ALG_SID_RC4,
+    CALG_SEAL = ALG_CLASS_DATA_ENCRYPT | ALG_TYPE_STREAM | ALG_SID_SEAL,
+    CALG_DH_SF = ALG_CLASS_KEY_EXCHANGE | ALG_TYPE_DH | ALG_SID_DH_SANDF,
+    CALG_DH_EPHEM = ALG_CLASS_KEY_EXCHANGE | ALG_TYPE_DH | ALG_SID_DH_EPHEM,
+    CALG_AGREEDKEY_ANY = ALG_CLASS_KEY_EXCHANGE | ALG_TYPE_DH | ALG_SID_AGREED_KEY_ANY,
+    CALG_KEA_KEYX = ALG_CLASS_KEY_EXCHANGE | ALG_TYPE_DH | ALG_SID_KEA,
+    CALG_HUGHES_MD5 = ALG_CLASS_KEY_EXCHANGE | ALG_TYPE_ANY | ALG_SID_MD5,
+    CALG_SKIPJACK = ALG_CLASS_DATA_ENCRYPT | ALG_TYPE_BLOCK | ALG_SID_SKIPJACK,
+    CALG_TEK = ALG_CLASS_DATA_ENCRYPT | ALG_TYPE_BLOCK | ALG_SID_TEK,
+    CALG_CYLINK_MEK = ALG_CLASS_DATA_ENCRYPT | ALG_TYPE_BLOCK | ALG_SID_CYLINK_MEK,
+    CALG_SSL3_SHAMD5 = ALG_CLASS_HASH | ALG_TYPE_ANY | ALG_SID_SSL3SHAMD5,
+    CALG_SSL3_MASTER = ALG_CLASS_MSG_ENCRYPT | ALG_TYPE_SECURECHANNEL | ALG_SID_SSL3_MASTER,
+    CALG_SCHANNEL_MASTER_HASH = ALG_CLASS_MSG_ENCRYPT | ALG_TYPE_SECURECHANNEL | ALG_SID_SCHANNEL_MASTER_HASH,
+    CALG_SCHANNEL_MAC_KEY = ALG_CLASS_MSG_ENCRYPT | ALG_TYPE_SECURECHANNEL | ALG_SID_SCHANNEL_MAC_KEY,
+    CALG_SCHANNEL_ENC_KEY = ALG_CLASS_MSG_ENCRYPT | ALG_TYPE_SECURECHANNEL | ALG_SID_SCHANNEL_ENC_KEY,
+    CALG_PCT1_MASTER = ALG_CLASS_MSG_ENCRYPT | ALG_TYPE_SECURECHANNEL | ALG_SID_PCT1_MASTER,
+    CALG_SSL2_MASTER = ALG_CLASS_MSG_ENCRYPT | ALG_TYPE_SECURECHANNEL | ALG_SID_SSL2_MASTER,
+    CALG_TLS1_MASTER = ALG_CLASS_MSG_ENCRYPT | ALG_TYPE_SECURECHANNEL | ALG_SID_TLS1_MASTER,
+    CALG_RC5 = ALG_CLASS_DATA_ENCRYPT | ALG_TYPE_BLOCK | ALG_SID_RC5,
+    CALG_HMAC = ALG_CLASS_HASH | ALG_TYPE_ANY | ALG_SID_HMAC,
+    CALG_TLS1PRF = ALG_CLASS_HASH | ALG_TYPE_ANY | ALG_SID_TLS1PRF,
+    CALG_HASH_REPLACE_OWF = ALG_CLASS_HASH | ALG_TYPE_ANY | ALG_SID_HASH_REPLACE_OWF,
+    CALG_AES_128 = ALG_CLASS_DATA_ENCRYPT | ALG_TYPE_BLOCK | ALG_SID_AES_128,
+    CALG_AES_192 = ALG_CLASS_DATA_ENCRYPT | ALG_TYPE_BLOCK | ALG_SID_AES_192,
+    CALG_AES_256 = ALG_CLASS_DATA_ENCRYPT | ALG_TYPE_BLOCK | ALG_SID_AES_256,
+    CALG_AES = ALG_CLASS_DATA_ENCRYPT | ALG_TYPE_BLOCK | ALG_SID_AES,
+    CALG_SHA_256 = ALG_CLASS_HASH | ALG_TYPE_ANY | ALG_SID_SHA_256,
+    CALG_SHA_384 = ALG_CLASS_HASH | ALG_TYPE_ANY | ALG_SID_SHA_384,
+    CALG_SHA_512 = ALG_CLASS_HASH | ALG_TYPE_ANY | ALG_SID_SHA_512,
+    CALG_ECDH = ALG_CLASS_KEY_EXCHANGE | ALG_TYPE_DH | ALG_SID_ECDH,
+    CALG_ECDH_EPHEM = ALG_CLASS_KEY_EXCHANGE | ALG_TYPE_ECDH | ALG_SID_ECDH_EPHEM,
+    CALG_ECMQV = ALG_CLASS_KEY_EXCHANGE | ALG_TYPE_ANY | ALG_SID_ECMQV,
+    CALG_ECDSA = ALG_CLASS_SIGNATURE | ALG_TYPE_DSS | ALG_SID_ECDSA,
+    CALG_NULLCIPHER = ALG_CLASS_DATA_ENCRYPT | ALG_TYPE_ANY | 0,
+    CALG_THIRDPARTY_KEY_EXCHANGE = ALG_CLASS_KEY_EXCHANGE | ALG_TYPE_THIRDPARTY | ALG_SID_THIRDPARTY_ANY,
+    CALG_THIRDPARTY_SIGNATURE = ALG_CLASS_SIGNATURE | ALG_TYPE_THIRDPARTY | ALG_SID_THIRDPARTY_ANY,
+    CALG_THIRDPARTY_CIPHER = ALG_CLASS_DATA_ENCRYPT | ALG_TYPE_THIRDPARTY | ALG_SID_THIRDPARTY_ANY,
+    CALG_THIRDPARTY_HASH = ALG_CLASS_HASH | ALG_TYPE_THIRDPARTY | ALG_SID_THIRDPARTY_ANY,
+}
+
+public enum SchannelCryptoUsage
+{
+    KeyExchange,
+    Signature,
+    Cipher,
+    Digest,
+    CertSig,
+}
+
+[Flags]
+public enum SchannelCredFlags : uint
+{
+    None = 0,
+    SCH_CRED_NO_SYSTEM_MAPPER = 0x00000002,
+    SCH_CRED_NO_SERVERNAME_CHECK = 0x00000004,
+    SCH_CRED_MANUAL_CRED_VALIDATION = 0x00000008,
+    SCH_CRED_NO_DEFAULT_CREDS = 0x00000010,
+    SCH_CRED_AUTO_CRED_VALIDATION = 0x00000020,
+    SCH_CRED_USE_DEFAULT_CREDS = 0x00000040,
+    SCH_CRED_DISABLE_RECONNECTS = 0x00000080,
+    SCH_CRED_REVOCATION_CHECK_END_CERT = 0x00000100,
+    SCH_CRED_REVOCATION_CHECK_CHAIN = 0x00000200,
+    SCH_CRED_REVOCATION_CHECK_CHAIN_EXCLUDE_ROOT = 0x00000400,
+    SCH_CRED_IGNORE_NO_REVOCATION_CHECK = 0x00000800,
+    SCH_CRED_IGNORE_REVOCATION_OFFLINE = 0x00001000,
+    SCH_CRED_RESTRICTED_ROOTS = 0x00002000,
+    SCH_CRED_REVOCATION_CHECK_CACHE_ONLY = 0x00004000,
+    SCH_CRED_CACHE_ONLY_URL_RETRIEVAL = 0x00008000,
+    SCH_CRED_MEMORY_STORE_CERT = 0x00010000,
+    SCH_CRED_CACHE_ONLY_URL_RETRIEVAL_ON_CREATE = 0x00020000,
+    SCH_SEND_ROOT_CERT = 0x00040000,
+    SCH_CRED_SNI_CREDENTIAL = 0x0008000,
+    SCH_CRED_SNI_ENABLE_OCSP = 0x00100000,
+    SCH_SEND_AUX_RECORD = 0x00200000,
+    SCH_USE_STRONG_CRYPTO = 0x00400000,
+    SCH_USE_PRESHAREDKEY_ONLY = 0x00800000,
+    SCH_USE_DTLS_ONLY = 0x01000000,
+    SCH_ALLOW_NULL_ENCRYPTION = 0x02000000,
+    SCH_CRED_DEFERRED_CRED_VALIDATION = 0x04000000,
+}
+
+public enum SchannelCredFormat
+{
+    SCH_CRED_FORMAT_CERT_CONTEXT = 0x00000000,
+    SCH_CRED_FORMAT_CERT_HASH = 0x00000001,
+    SCH_CRED_FORMAT_CERT_HASH_STORE = 0x00000002,
+}
+
+[Flags]
+public enum SchannelProtocols : uint
+{
+    SP_PROT_NONE = 0,
+
+    SP_PROT_PCT1_SERVER = 0x00000001,
+    SP_PROT_PCT1_CLIENT = 0x00000002,
+    SP_PROT_PCT1 = SP_PROT_PCT1_SERVER | SP_PROT_PCT1_CLIENT,
+
+    SP_PROT_SSL2_SERVER = 0x00000004,
+    SP_PROT_SSL2_CLIENT = 0x00000008,
+    SP_PROT_SSL2 = SP_PROT_SSL2_SERVER | SP_PROT_SSL2_CLIENT,
+
+    SP_PROT_SSL3_SERVER = 0x00000010,
+    SP_PROT_SSL3_CLIENT = 0x00000020,
+    SP_PROT_SSL3 = SP_PROT_SSL3_SERVER | SP_PROT_SSL3_CLIENT,
+
+    SP_PROT_TLS1_SERVER = 0x00000040,
+    SP_PROT_TLS1_CLIENT = 0x00000080,
+    SP_PROT_TLS1 = SP_PROT_TLS1_SERVER | SP_PROT_TLS1_CLIENT,
+
+    SP_PROT_SSL3TLS1_CLIENTS = SP_PROT_TLS1_CLIENT | SP_PROT_TLS1_CLIENT,
+    SP_PROT_SSL3TLS1_SERVERS = SP_PROT_TLS1_SERVER | SP_PROT_SSL3_SERVER,
+    SP_PROT_SSL3TLS1 = SP_PROT_SSL3 | SP_PROT_TLS1,
+
+    SP_PROT_TLS1_0_SERVER = SP_PROT_TLS1_SERVER,
+    SP_PROT_TLS1_0_CLIENT = SP_PROT_TLS1_CLIENT,
+    SP_PROT_TLS1_0 = SP_PROT_TLS1_0_SERVER | SP_PROT_TLS1_0_CLIENT,
+
+    SP_PROT_TLS1_1_SERVER = 0x00000100,
+    SP_PROT_TLS1_1_CLIENT = 0x00000200,
+    SP_PROT_TLS1_1 = SP_PROT_TLS1_1_SERVER | SP_PROT_TLS1_1_CLIENT,
+
+    SP_PROT_TLS1_2_SERVER = 0x00000400,
+    SP_PROT_TLS1_2_CLIENT = 0x00000800,
+    SP_PROT_TLS1_2 = SP_PROT_TLS1_2_SERVER | SP_PROT_TLS1_2_CLIENT,
+
+    SP_PROT_TLS1_3_SERVER = 0x00001000,
+    SP_PROT_TLS1_3_CLIENT = 0x00002000,
+    SP_PROT_TLS1_3 = SP_PROT_TLS1_3_SERVER | SP_PROT_TLS1_3_CLIENT,
+
+    SP_PROT_DTLS_SERVER = 0x00010000,
+    SP_PROT_DTLS_CLIENT = 0x00020000,
+    SP_PROT_DTLS = SP_PROT_DTLS_SERVER | SP_PROT_DTLS_CLIENT,
+
+    SP_PROT_DTLS1_0_SERVER = SP_PROT_DTLS_SERVER,
+    SP_PROT_DTLS1_0_CLIENT = SP_PROT_DTLS_CLIENT,
+    SP_PROT_DTLS1_0 = SP_PROT_DTLS1_0_SERVER | SP_PROT_DTLS1_0_CLIENT,
+
+    SP_PROT_DTLS1_2_SERVER = 0x00040000,
+    SP_PROT_DTLS1_2_CLIENT = 0x00080000,
+    SP_PROT_DTLS1_2 = SP_PROT_DTLS1_2_SERVER | SP_PROT_DTLS1_2_CLIENT,
+
+    SP_PROT_UNI_SERVER = 0x40000000,
+    SP_PROT_UNI_CLIENT = 0x80000000,
+    SP_PROT_UNI = SP_PROT_UNI_SERVER | SP_PROT_UNI_CLIENT,
+
+    SP_PROT_ALL = 0xFFFFFFFF,
+    SP_PROT_CLIENTS = SP_PROT_PCT1_CLIENT | SP_PROT_SSL2_CLIENT | SP_PROT_SSL3_CLIENT | SP_PROT_UNI_CLIENT | SP_PROT_TLS1_CLIENT,
+    SP_PROT_SERVERS = SP_PROT_PCT1_SERVER | SP_PROT_SSL2_SERVER | SP_PROT_SSL3_SERVER | SP_PROT_UNI_SERVER | SP_PROT_TLS1_SERVER,
+}

--- a/src/SecBuffer.cs
+++ b/src/SecBuffer.cs
@@ -63,7 +63,10 @@ public class SecurityBuffer : ISecBuffer
     internal SecurityBuffer(Helpers.SecBuffer buffer)
     {
         Data = new byte[buffer.cbBuffer];
-        Marshal.Copy(buffer.pvBuffer, Data, 0, Data.Length);
+        if (buffer.pvBuffer != IntPtr.Zero)
+        {
+            Marshal.Copy(buffer.pvBuffer, Data, 0, Data.Length);
+        }
         Type = (SecBufferType)(buffer.BufferType & ~0xF0000000);
         Flags = (SecBufferFlags)(buffer.BufferType & 0xF0000000);
     }

--- a/tests/Get-SchannelCredential.Tests.ps1
+++ b/tests/Get-SchannelCredential.Tests.ps1
@@ -1,0 +1,116 @@
+. ([IO.Path]::Combine($PSScriptRoot, 'common.ps1'))
+
+Describe "Schannel SCHANNEL_CRED" {
+    BeforeAll {
+        $Target = "test-host.domain.com"
+
+        $certParams = @{
+            DnsName           = $Target
+            CertStoreLocation = "Cert:\LocalMachine\My"
+        }
+        $ServerCert = New-SelfSignedCertificate @certParams
+        Remove-Item -LiteralPath "Cert:\LocalMachine\My\$($ServerCert.Thumbprint)" -Force -Confirm:$false
+
+        $rootStore = Get-Item Cert:\LocalMachine\Root
+        $rootStore.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite)
+        try {
+            $rootStore.Add($ServerCert)
+        }
+        finally {
+            $rootStore.Dispose()
+        }
+    }
+    AfterAll {
+        Remove-Item -LiteralPath "Cert:\LocalMachine\Root\$($ServerCert.Thumbprint)" -Force -Confirm:$false
+    }
+    It "Authenticates with Defaults" {
+        $cCred = Get-SchannelCredential
+        $sCred = Get-SchannelCredential -CredentialUse SECPKG_CRED_INBOUND -Certificate $ServerCert
+
+        $cCtx, $sCtx = Complete-TlsAuth -Client $cCred -Server $sCred -Target $Target
+        $cActual = Get-SecContextCipherInfo -Context $cCtx
+        $sActual = Get-SecContextCipherInfo -Context $sCtx
+
+        $cActual | Should -BeOfType ([PSSPI.Commands.CipherInfo])
+        $cActual.Protocol | Should -Be ([PSSPI.Commands.TlsProtocol]::TLS1_2)
+        $cActual.CipherSuite | Should -Be TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+        $cActual.Cipher | Should -Be AES
+        $cActual.CipherLength | Should -Be 256
+
+        $sActual | Should -BeOfType ([PSSPI.Commands.CipherInfo])
+        $sActual.Protocol | Should -Be ([PSSPI.Commands.TlsProtocol]::TLS1_2)
+        $sActual.CipherSuite | Should -Be TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+        $sActual.Cipher | Should -Be AES
+        $sActual.CipherLength | Should -Be 256
+    }
+
+    It "Authenticates with explicit protocol" {
+        $cCred = Get-SchannelCredential -Protocol SP_PROT_TLS1_2
+        $sCred = Get-SchannelCredential -CredentialUse SECPKG_CRED_INBOUND -Certificate $ServerCert
+
+        $cCtx, $sCtx = Complete-TlsAuth -Client $cCred -Server $sCred -Target $Target
+        $cActual = Get-SecContextCipherInfo -Context $cCtx
+        $sActual = Get-SecContextCipherInfo -Context $sCtx
+
+        $cActual | Should -BeOfType ([PSSPI.Commands.CipherInfo])
+        $cActual.Protocol | Should -Be ([PSSPI.Commands.TlsProtocol]::TLS1_2)
+        $cActual.CipherSuite | Should -Be TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+        $cActual.Cipher | Should -Be AES
+        $cActual.CipherLength | Should -Be 256
+
+        $sActual | Should -BeOfType ([PSSPI.Commands.CipherInfo])
+        $sActual.Protocol | Should -Be ([PSSPI.Commands.TlsProtocol]::TLS1_2)
+        $sActual.CipherSuite | Should -Be TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+        $sActual.Cipher | Should -Be AES
+        $sActual.CipherLength | Should -Be 256
+    }
+
+    It "Authenticates with maximum cipher strength" {
+        $cCred = Get-SchannelCredential -MaximumCipherStrength 128
+        $sCred = Get-SchannelCredential -CredentialUse SECPKG_CRED_INBOUND -Certificate $ServerCert
+
+        $cCtx, $sCtx = Complete-TlsAuth -Client $cCred -Server $sCred -Target $Target
+        $cActual = Get-SecContextCipherInfo -Context $cCtx
+        $sActual = Get-SecContextCipherInfo -Context $sCtx
+
+        $cActual | Should -BeOfType ([PSSPI.Commands.CipherInfo])
+        $cActual.Protocol | Should -Be ([PSSPI.Commands.TlsProtocol]::TLS1_2)
+        $cActual.CipherSuite | Should -Be TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        $cActual.Cipher | Should -Be AES
+        $cActual.CipherLength | Should -Be 128
+
+        $sActual | Should -BeOfType ([PSSPI.Commands.CipherInfo])
+        $sActual.Protocol | Should -Be ([PSSPI.Commands.TlsProtocol]::TLS1_2)
+        $sActual.CipherSuite | Should -Be TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        $sActual.Cipher | Should -Be AES
+        $sActual.CipherLength | Should -Be 128
+    }
+
+    It "Authenticates with explicit algorithms" {
+        $cCred = Get-SchannelCredential -SupportedAlgs CALG_AES_128
+        $sCred = Get-SchannelCredential -CredentialUse SECPKG_CRED_INBOUND -Certificate $ServerCert
+
+        $cCtx, $sCtx = Complete-TlsAuth -Client $cCred -Server $sCred -Target $Target
+        $cActual = Get-SecContextCipherInfo -Context $cCtx
+        $sActual = Get-SecContextCipherInfo -Context $sCtx
+
+        $cActual | Should -BeOfType ([PSSPI.Commands.CipherInfo])
+        $cActual.Protocol | Should -Be ([PSSPI.Commands.TlsProtocol]::TLS1_2)
+        $cActual.CipherSuite | Should -Be TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        $cActual.Cipher | Should -Be AES
+        $cActual.CipherLength | Should -Be 128
+
+        $sActual | Should -BeOfType ([PSSPI.Commands.CipherInfo])
+        $sActual.Protocol | Should -Be ([PSSPI.Commands.TlsProtocol]::TLS1_2)
+        $sActual.CipherSuite | Should -Be TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        $sActual.Cipher | Should -Be AES
+        $sActual.CipherLength | Should -Be 128
+    }
+
+    It "Doesn't provide cert with inbound credential" {
+        $out = Get-SCHCredential -CredentialUse SECPKG_CRED_INBOUND -ErrorAction SilentlyContinue -ErrorVariable err
+        $out | Should -BeNullOrEmpty
+        $err.Count | Should -Be 1
+        [string]$err[0] | Should -BeLike "*At least one certificate must be specified when using SECPKG_CRED_INBOUND*"
+    }
+}

--- a/tests/New-CryptoSettings.Tests.ps1
+++ b/tests/New-CryptoSettings.Tests.ps1
@@ -1,0 +1,87 @@
+. ([IO.Path]::Combine($PSScriptRoot, 'common.ps1'))
+
+Describe "New-CryptoSetting" {
+    It "Tries to provide too many chaining modes" {
+        $chainingModes = @("mode") * 17
+        $out = New-CryptoSetting -Usage Digest -Algorithm test -ChainingMode $chainingModes -ErrorAction SilentlyContinue -ErrorVariable err
+        $out | Should -BeNullOrEmpty
+        $err.Count | Should -Be 1
+        [string]$err[0] | Should -BeLike "*Crypto Settings can not have more than 16 chaining modes specified*"
+    }
+
+    It "Completes chaining mode" {
+        $actual = Complete 'New-CryptoSetting -ChainingMode '
+        $actual.Count | Should -Be 6
+        $actual | ForEach-Object {
+            $_.CompletionText | Should -BeIn @(
+                "ChainingModeCBC"
+                "ChainingModeCCM"
+                "ChainingModeCFB"
+                "ChainingModeECB"
+                "ChainingModeGCM"
+                "ChainingModeN/A"
+            )
+        }
+    }
+
+    It "Completes chaining mode with partial match" {
+        $actual = Complete 'New-CryptoSetting -ChainingMode chainingmodee'
+        $actual.Count | Should -Be 1
+        $actual.CompletionText | Should -Be ChainingModeECB
+    }
+
+    It "Completes algorithm with no usage" {
+        $actual = Complete "New-CryptoSetting -Algorithm "
+        $actual.Count | Should -Be 18
+        $actual | ForEach-Object {
+            $_.CompletionText | Should -BeIn @(
+                "3DES"
+                "AES"
+                "CHACHA20_POLY1305"
+                "DES"
+                "DH"
+                "DSA"
+                "DSS"
+                "ECDH"
+                "ECDSA"
+                "EXPORT"
+                "EXPORT1024"
+                "MD5"
+                "PSK"
+                "RC4"
+                "RSA"
+                "SHA1"
+                "SHA256"
+                "SHA384"
+            )
+        }
+    }
+
+    It "Completes algorithm with partial match" {
+        $actual = Complete "New-CryptoSetting -Algorithm ae"
+        $actual.Count | Should -Be 1
+        $actual.CompletionText | Should -Be AES
+    }
+
+    It "Completes algorithm with <Usage> usage" -TestCases @(
+        @{ Usage = "KeyExchange"; Expected = @("DH", "ECDH", "PSK", "RSA") }
+        @{ Usage = "Signature"; Expected = @("DSA", "DSS", "ECDSA", "EXPORT", "EXPORT1024", "RSA") }
+        @{ Usage = "Cipher"; Expected = @("3DES", "AES", "DES", "CHACHA20_POLY1305", "RC4") }
+        @{ Usage = "Digest"; Expected = @("MD5", "SHA1", "SHA256", "SHA384") }
+        @{ Usage = "CertSig"; Expected = @("DSA", "ECDSA", "RSA", "SHA1", "SHA256") }
+    ) {
+        param($Usage, $Expected)
+
+        $actual = Complete "New-CryptoSetting -Usage $Usage -Algorithm "
+        $actual.Count | Should -Be $Expected.Count
+        $actual | ForEach-Object {
+            $_.CompletionText | Should -BeIn $Expected
+        }
+    }
+
+    It "Completes algorithm with usage variable" {
+        $actual = Complete "New-CryptoSetting -Usage ([PSSPI.SchannelCryptoUsage]::Cipher) -Algorithm ae"
+        $actual.Count | Should -Be 1
+        $actual.CompletionText | Should -Be AES
+    }
+}

--- a/tests/New-TlsParameter.Tests.ps1
+++ b/tests/New-TlsParameter.Tests.ps1
@@ -1,0 +1,19 @@
+. ([IO.Path]::Combine($PSScriptRoot, 'common.ps1'))
+
+Describe "New-TlsParameter" {
+    It "Tries to provide too many ALPN Ids" {
+        $alpnIds = @("mode") * 17
+        $out = New-TlsParameter -AlpnId $alpnIds -ErrorAction SilentlyContinue -ErrorVariable err
+        $out | Should -BeNullOrEmpty
+        $err.Count | Should -Be 1
+        [string]$err[0] | Should -BeLike "*TLS Parameters can not have more than 16 ALPN Ids specified*"
+    }
+
+    It "Tries to provide too many crypto settings" {
+        $cs = @(New-CryptoSetting -Usage Digest -Algorithm AES) * 17
+        $out = New-TlsParameter -DisabledCrypto $cs -ErrorAction SilentlyContinue -ErrorVariable err
+        $out | Should -BeNullOrEmpty
+        $err.Count | Should -Be 1
+        [string]$err[0] | Should -BeLike "*TLS Parameters can not have more than 16 crypto settings specified*"
+    }
+}

--- a/tests/common.ps1
+++ b/tests/common.ps1
@@ -21,3 +21,74 @@ Function Global:Complete {
         $Expression.Length,
         $null).CompletionMatches
 }
+
+Function Global:Complete-TlsAuth {
+    [OutputType([PSSPI.SecurityContext])]
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [PSSPI.Credential]$Client,
+
+        [Parameter(Mandatory)]
+        [PSSPI.Credential]$Server,
+
+        [Parameter(Mandatory)]
+        [string]$Target
+    )
+
+    $cCtx = New-SecContext -Credential $Client
+    $sCtx = New-SecContext -Credential $Server
+
+    $sRes = $null
+    while ($true) {
+        $stepParams = @{
+            Context    = $cCtx
+            Target     = $Target
+            ContextReq = 'ISC_REQ_SEQUENCE_DETECT, ISC_REQ_REPLAY_DETECT, ISC_REQ_CONFIDENTIALITY, ISC_REQ_ALLOCATE_MEMORY, ISC_REQ_STREAM'
+        }
+
+        if ($sRes) {
+            $stepParams.InputBuffer = @(
+                $sRes.Buffers[0]
+                'SECBUFFER_EMPTY'
+            )
+            $stepParams.OutputBuffer = @(
+                'SECBUFFER_TOKEN',
+                'SECBUFFER_ALERT',
+                'SECBUFFER_EMPTY'
+            )
+        }
+        else {
+            $stepParams.OutputBuffer = 'SECBUFFER_EMPTY'
+        }
+
+        $cRes = Step-InitSecContext @stepParams
+        if ($cRes.Buffers[0].Length -eq 0) {
+            break
+        }
+
+        $stepParams = @{
+            Context      = $sCtx
+            ContextReq   = 'ASC_REQ_ALLOCATE_MEMORY'
+            InputBuffer  = @(
+                $cRes.Buffers[0]
+                'SECBUFFER_EMPTY'
+            )
+            OutputBuffer = 'SECBUFFER_TOKEN'
+        }
+
+        $sRes = Step-AcceptSecContext @stepParams
+        if ($sRes.Buffers[0].Length -eq 0) {
+            break
+        }
+    }
+
+    if ($cRes.Result -ne [PSSPI.SecContextStatus]::Ok) {
+        throw "Client context is not complete and there's no more server data: $($cRes.Result)"
+    }
+    if ($sRes.Result -ne [PSSPI.SecContextStatus]::Ok) {
+        throw "Server context is not complete and there's no more client data: $($sRes.Result)"
+    }
+
+    $cCtx, $sCtx
+}

--- a/tools/AssertPwsh.ps1
+++ b/tools/AssertPwsh.ps1
@@ -1,0 +1,68 @@
+using namespace System.IO
+using namespace System.Net
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$RequiredVersion
+)
+end {
+    $targetFolder = $PSCmdlet.GetUnresolvedProviderPathFromPSPath(
+        "$PSScriptRoot/../output/pwsh-$RequiredVersion")
+
+    if ($IsWindows) {
+        $downloadUrl = "https://github.com/PowerShell/PowerShell/releases/download/v$RequiredVersion/PowerShell-$RequiredVersion-win-x64.zip"
+        $fileName = "pwsh-$RequiredVersion.zip"
+        $nativeExt = ".exe"
+    }
+    else {
+        $downloadUrl = "https://github.com/PowerShell/PowerShell/releases/download/v$RequiredVersion/powershell-$RequiredVersion-linux-x64.tar.gz"
+        $fileName = "pwsh-$RequiredVersion.tar.gz"
+        $nativeExt = ""
+    }
+
+    if (Test-Path "$targetFolder\pwsh$nativeExt") {
+        return
+    }
+
+    if (-not (Test-Path $targetFolder)) {
+        $null = New-Item $targetFolder -ItemType Directory -Force
+    }
+
+    $oldSecurityProtocol = [ServicePointManager]::SecurityProtocol
+    try {
+        & {
+            $ProgressPreference = 'SilentlyContinue'
+            [ServicePointManager]::SecurityProtocol = 'Tls12'
+            Invoke-WebRequest -UseBasicParsing -Uri $downloadUrl -OutFile $targetFolder/$fileName
+        }
+    }
+    finally {
+        [ServicePointManager]::SecurityProtocol = $oldSecurityProtocol
+    }
+
+    if ($IsWindows) {
+        $oldPreference = $global:ProgressPreference
+        try {
+            $global:ProgressPreference = 'SilentlyContinue'
+            Expand-Archive -LiteralPath $targetFolder/$fileName -DestinationPath $targetFolder
+        }
+        finally {
+            $global:ProgressPreference = $oldPreference
+        }
+    }
+    else {
+        tar -xf $targetFolder/$fileName --directory $targetFolder
+        if ($LASTEXITCODE) {
+            throw "Failed to extract pwsh tar for $RequiredVersion"
+        }
+
+        chmod +x $targetFolder/$fileName
+        if ($LASTEXITCODE) {
+            throw "Failed to set pwsh as executable at $targetFolder/$fileName"
+        }
+    }
+
+    Remove-Item -LiteralPath $targetFolder/$fileName -Force -Confirm:$false
+}


### PR DESCRIPTION
Add support for Schannel operations like TLS handshakes. This implements both the old and new Schannel structures that can be used for TLS 1.3 operations.