### PR TITLE
Add Get-SecContextSizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for PSSPI
 
+## v0.5.0 - TBD
+
++ Added the following cmdlets
+  + `Get-SecContextSizes` - Gets sizes of various context messages of a security context.
+
 ## v0.4.0 - 2022-12-06
 
 + Added the following cmdlets

--- a/docs/en-US/Get-SecContextSizes.md
+++ b/docs/en-US/Get-SecContextSizes.md
@@ -1,0 +1,76 @@
+---
+external help file: PSSPI.dll-Help.xml
+Module Name: PSSPI
+online version: https://www.github.com/jborean93/PSSPI/blob/main/docs/en-US/Get-SecContextSizes.md
+schema: 2.0.0
+---
+
+# Get-SecContextSizes
+
+## SYNOPSIS
+Gets the sizes of important structures used in message support functions.
+
+## SYNTAX
+
+```
+Get-SecContextSizes -Context <SecurityContext[]> [<CommonParameters>]
+```
+
+## DESCRIPTION
+Gets the various message sizes of a security context, for example the size of a security token, header/trailer used in signatures/encryption, and more.
+
+## EXAMPLES
+
+### Example 1 - Get context sizes
+```powershell
+PS C:\> $ctx = New-SecContext
+PS C:\> ... Complete auth
+PS C:\> Get-SecContextSizes -Context $ctx
+```
+
+Gets the sizes associated with the negotiated security context.
+
+## PARAMETERS
+
+### -Context
+The security context to query.
+This context must have completed the authentication stage until it has been marked as Ok from `Step-InitSecContext` or `Step-AcceptSecContext`.
+
+```yaml
+Type: SecurityContext[]
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### PSSPI.SecurityContext[]
+An array of security contexts can be piped into this cmdlet.
+
+## OUTPUTS
+
+### PSSPI.Commands.ContextSizes
+The ContextSizes object contains the following properties
+
++ `MaxToken` - Maximum size of the security token used in the authentication exchanges
+
++ `MaxSignature` - Maximum size of the signatures created by this security context, will be 0 if integrity services are not negotiated
+
++ `BlockSize` - Preferred integral size of the messages, e.g. 8 indicates messages should be of size zero mod eight for optimal performance
+
++ `SecurityTrailer` - Size of the security trailer to be appended to messages
+
+## NOTES
+
+## RELATED LINKS
+
+[SecPkgContext_Sizes](https://learn.microsoft.com/en-us/windows/win32/api/sspi/ns-sspi-secpkgcontext_sizes)

--- a/module/PSSPI.psd1
+++ b/module/PSSPI.psd1
@@ -14,7 +14,7 @@
     RootModule             = 'bin/netcoreapp3.1/PSSPI.dll'
 
     # Version number of this module.
-    ModuleVersion          = '0.4.0'
+    ModuleVersion          = '0.5.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -75,6 +75,7 @@
         'Get-SCHCredential'
         'Get-SecContextCipherInfo'
         'Get-SecContextRemoteCert'
+        'Get-SecContextSizes'
         'Get-SSPICredential'
         'Get-SSPIPackage'
         'New-ChannelBindingBuffer'

--- a/src/Commands/SecContextSizes.cs
+++ b/src/Commands/SecContextSizes.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Management.Automation;
+
+namespace PSSPI.Commands;
+
+[Cmdlet(
+    VerbsCommon.Get, "SecContextSizes"
+)]
+[OutputType(typeof(ContextSizes))]
+public class GetSecContextSizes : PSCmdlet
+{
+    [Parameter(
+        Mandatory = true,
+        ValueFromPipeline = true,
+        ValueFromPipelineByPropertyName = true
+    )]
+    public SecurityContext[] Context { get; set; } = Array.Empty<SecurityContext>();
+
+    protected override void ProcessRecord()
+    {
+        foreach (SecurityContext context in Context)
+        {
+            Span<Helpers.SecPkgContext_Sizes> sizes = new(new Helpers.SecPkgContext_Sizes[1]);
+            unsafe
+            {
+                fixed (Helpers.SecPkgContext_Sizes* sizesPtr = sizes)
+                {
+                    SSPI.QueryContextAttributes(context.SafeHandle, SecPkgAttribute.SECPKG_ATTR_SIZES, (void*)sizesPtr);
+                }
+
+                WriteObject(new ContextSizes(sizes[0].cbMaxToken, sizes[0].cbMaxSignature, sizes[0].cbBlockSize,
+                    sizes[0].cbSecurityTrailer));
+            }
+        }
+    }
+}
+
+public sealed class ContextSizes
+{
+    public UInt32 MaxToken { get; }
+    public UInt32 MaxSignature { get; }
+    public UInt32 BlockSize { get; }
+    public UInt32 SecurityTrailer { get; }
+
+    public ContextSizes(uint maxToken, uint maxSignature, uint blockSize, uint securityTrailer)
+    {
+        MaxToken = maxToken;
+        MaxSignature = maxSignature;
+        BlockSize = blockSize;
+        SecurityTrailer = securityTrailer;
+    }
+}

--- a/tests/Step-SecContext.Tests.ps1
+++ b/tests/Step-SecContext.Tests.ps1
@@ -36,6 +36,21 @@ Describe "Step-*SecContext" {
         $sRes2.Buffers[0].Type | Should -Be ([PSSPI.SecBufferType]::SECBUFFER_TOKEN)
         $sRes2.Buffers[0].Data | Should -Be $null
         $sRes2.Flags | Should -Be ([PSSPI.AcceptorContextReturnFlags]::NONE)
+
+        # NTLM has a fixed signature/header size of 16 and no block size
+        $cSizes = Get-SecContextSizes -Context $cCtx
+        $cSizes | Should -BeOfType ([PSSPI.Commands.ContextSizes])
+        $cSizes.MaxToken | Should -BeOfType ([System.UInt32])
+        $cSizes.MaxSignature | Should -Be 16
+        $cSizes.BlockSize | Should -Be 0
+        $cSizes.SecurityTrailer | Should -Be 16
+
+        $sSizes = Get-SecContextSizes -Context $sCtx
+        $sSizes | Should -BeOfType ([PSSPI.Commands.ContextSizes])
+        $sSizes.MaxToken | Should -BeOfType ([System.UInt32])
+        $sSizes.MaxSignature | Should -Be 16
+        $sSizes.BlockSize | Should -Be 0
+        $sSizes.SecurityTrailer | Should -Be 16
     }
 
     It "Steps through NTLM exchange with null transform buffer" {


### PR DESCRIPTION
Added the Get-SecContextSizes to retrieve the security context message sizes as exposed by SecPkgContext_Sizes.